### PR TITLE
refactor: unify AMap API key configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ npm run dev
 | 变量 | 必需 | 说明 |
 |------|------|------|
 | `MONGODB_URI` | ✅ | MongoDB Atlas 连接字符串 |
-| `AMAP_WEB_API_KEY` | ✅ | 高德地图 Web 服务 API Key (天气/逆地理编码) |
+| `NEXT_PUBLIC_AMAP_KEY` | ✅ | 高德地图 API Key (地图展示 + 天气查询) |
 
 > 生产环境变量在 Vercel 项目设置中配置
 

--- a/src/app/api/weather/route.ts
+++ b/src/app/api/weather/route.ts
@@ -171,10 +171,10 @@ async function fetchWeatherData(
  */
 export async function GET(request: NextRequest) {
   try {
-    const apiKey = process.env.AMAP_WEB_API_KEY
+    const apiKey = process.env.NEXT_PUBLIC_AMAP_KEY
 
     if (!apiKey) {
-      console.error('[Weather] AMAP_WEB_API_KEY not configured')
+      console.error('[Weather] NEXT_PUBLIC_AMAP_KEY not configured')
       return NextResponse.json(
         { error: '天气服务未配置' },
         { status: 503 }

--- a/src/components/amap-container.tsx
+++ b/src/components/amap-container.tsx
@@ -4,8 +4,8 @@ import { useEffect, useRef, useState } from 'react'
 import { MapPin, Navigation, Maximize2 } from 'lucide-react'
 import type { Coordinates, ApproachPath } from '@/types'
 
-// 高德地图 API Key
-const AMAP_KEY = '74353b0f808e720ded79b9495c101656'
+// 高德地图 API Key (从环境变量读取)
+const AMAP_KEY = process.env.NEXT_PUBLIC_AMAP_KEY || ''
 
 interface AMapContainerProps {
   /** 地图中心点坐标 */


### PR DESCRIPTION
## Summary
- Unify AMap API key configuration to use `NEXT_PUBLIC_AMAP_KEY` for both map display and weather services
- Update `amap-container.tsx` to read API key from environment variable instead of hardcoded value
- Update documentation in `CLAUDE.md`

## Changes
- `src/app/api/weather/route.ts` - Use `NEXT_PUBLIC_AMAP_KEY` instead of `AMAP_WEB_API_KEY`
- `src/components/amap-container.tsx` - Read key from `process.env.NEXT_PUBLIC_AMAP_KEY`
- `CLAUDE.md` - Update environment variable documentation

## Related
Follow-up to #14 (weather feature implementation)

## Test plan
- [x] Verify map display works with the unified API key
- [x] Verify weather API returns data correctly
- [x] Configure `NEXT_PUBLIC_AMAP_KEY` in Vercel Dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)