### PR TITLE
test: add unit tests for core UX modules (P0 + P1)

### DIFF
--- a/src/components/theme-switcher.test.tsx
+++ b/src/components/theme-switcher.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * 主题切换器组件测试
+ *
+ * 测试覆盖:
+ * - 渲染三个主题选项
+ * - 选中态显示
+ * - 点击切换主题
+ * - 自动模式提示
+ * - 无障碍属性
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ThemeSwitcher } from './theme-switcher'
+
+// Mock next-themes
+const mockSetTheme = vi.fn()
+let mockTheme = 'light'
+let mockResolvedTheme = 'light'
+
+vi.mock('next-themes', () => ({
+  useTheme: () => ({
+    theme: mockTheme,
+    setTheme: mockSetTheme,
+    resolvedTheme: mockResolvedTheme,
+  }),
+}))
+
+describe('ThemeSwitcher', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockTheme = 'light'
+    mockResolvedTheme = 'light'
+  })
+
+  describe('渲染', () => {
+    it('渲染三个主题选项', () => {
+      render(<ThemeSwitcher />)
+
+      expect(screen.getByRole('tab', { name: /日间/i })).toBeInTheDocument()
+      expect(screen.getByRole('tab', { name: /暗夜/i })).toBeInTheDocument()
+      expect(screen.getByRole('tab', { name: /自动/i })).toBeInTheDocument()
+    })
+
+    it('渲染 tablist 容器', () => {
+      render(<ThemeSwitcher />)
+
+      const tablist = screen.getByRole('tablist')
+      expect(tablist).toBeInTheDocument()
+      expect(tablist).toHaveAttribute('aria-label', '主题模式选择')
+    })
+
+    it('每个选项都有正确的 ARIA 属性', () => {
+      render(<ThemeSwitcher />)
+
+      const tabs = screen.getAllByRole('tab')
+      expect(tabs).toHaveLength(3)
+
+      tabs.forEach((tab) => {
+        expect(tab).toHaveAttribute('aria-selected')
+        expect(tab).toHaveAttribute('aria-controls')
+      })
+    })
+  })
+
+  describe('选中态', () => {
+    it('light 模式下日间按钮选中', () => {
+      mockTheme = 'light'
+      render(<ThemeSwitcher />)
+
+      const lightTab = screen.getByRole('tab', { name: /日间/i })
+      expect(lightTab).toHaveAttribute('aria-selected', 'true')
+
+      const darkTab = screen.getByRole('tab', { name: /暗夜/i })
+      expect(darkTab).toHaveAttribute('aria-selected', 'false')
+    })
+
+    it('dark 模式下暗夜按钮选中', () => {
+      mockTheme = 'dark'
+      render(<ThemeSwitcher />)
+
+      const darkTab = screen.getByRole('tab', { name: /暗夜/i })
+      expect(darkTab).toHaveAttribute('aria-selected', 'true')
+
+      const lightTab = screen.getByRole('tab', { name: /日间/i })
+      expect(lightTab).toHaveAttribute('aria-selected', 'false')
+    })
+
+    it('system 模式下自动按钮选中', () => {
+      mockTheme = 'system'
+      render(<ThemeSwitcher />)
+
+      const systemTab = screen.getByRole('tab', { name: /自动/i })
+      expect(systemTab).toHaveAttribute('aria-selected', 'true')
+    })
+  })
+
+  describe('点击交互', () => {
+    it('点击暗夜按钮调用 setTheme("dark")', () => {
+      render(<ThemeSwitcher />)
+
+      const darkTab = screen.getByRole('tab', { name: /暗夜/i })
+      fireEvent.click(darkTab)
+
+      expect(mockSetTheme).toHaveBeenCalledWith('dark')
+    })
+
+    it('点击日间按钮调用 setTheme("light")', () => {
+      mockTheme = 'dark'
+      render(<ThemeSwitcher />)
+
+      const lightTab = screen.getByRole('tab', { name: /日间/i })
+      fireEvent.click(lightTab)
+
+      expect(mockSetTheme).toHaveBeenCalledWith('light')
+    })
+
+    it('点击自动按钮调用 setTheme("system")', () => {
+      render(<ThemeSwitcher />)
+
+      const systemTab = screen.getByRole('tab', { name: /自动/i })
+      fireEvent.click(systemTab)
+
+      expect(mockSetTheme).toHaveBeenCalledWith('system')
+    })
+  })
+
+  describe('自动模式提示', () => {
+    it('system 模式显示当前跟随的主题（暗夜）', () => {
+      mockTheme = 'system'
+      mockResolvedTheme = 'dark'
+      render(<ThemeSwitcher />)
+
+      expect(screen.getByText(/当前跟随系统：暗夜/i)).toBeInTheDocument()
+    })
+
+    it('system 模式显示当前跟随的主题（日间）', () => {
+      mockTheme = 'system'
+      mockResolvedTheme = 'light'
+      render(<ThemeSwitcher />)
+
+      expect(screen.getByText(/当前跟随系统：日间/i)).toBeInTheDocument()
+    })
+
+    it('非 system 模式不显示跟随提示', () => {
+      mockTheme = 'light'
+      render(<ThemeSwitcher />)
+
+      expect(screen.queryByText(/当前跟随系统/i)).not.toBeInTheDocument()
+    })
+
+    it('dark 模式不显示跟随提示', () => {
+      mockTheme = 'dark'
+      render(<ThemeSwitcher />)
+
+      expect(screen.queryByText(/当前跟随系统/i)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('样式一致性', () => {
+    it('所有按钮都有相同的基础类名', () => {
+      render(<ThemeSwitcher />)
+
+      const tabs = screen.getAllByRole('tab')
+      tabs.forEach((tab) => {
+        expect(tab.className).toContain('flex-1')
+        expect(tab.className).toContain('flex')
+        expect(tab.className).toContain('items-center')
+      })
+    })
+  })
+
+  describe('用户场景', () => {
+    it('用户从日间切换到暗夜', () => {
+      mockTheme = 'light'
+      render(<ThemeSwitcher />)
+
+      // 初始状态：日间选中
+      expect(screen.getByRole('tab', { name: /日间/i })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      )
+
+      // 点击暗夜
+      fireEvent.click(screen.getByRole('tab', { name: /暗夜/i }))
+      expect(mockSetTheme).toHaveBeenCalledWith('dark')
+    })
+
+    it('用户切换到自动模式后看到系统当前主题', () => {
+      mockTheme = 'system'
+      mockResolvedTheme = 'dark'
+      render(<ThemeSwitcher />)
+
+      // 自动模式选中
+      expect(screen.getByRole('tab', { name: /自动/i })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      )
+
+      // 显示当前跟随的主题
+      expect(screen.getByText(/当前跟随系统：暗夜/i)).toBeInTheDocument()
+    })
+  })
+})

--- a/src/hooks/use-city-selection.test.ts
+++ b/src/hooks/use-city-selection.test.ts
@@ -1,0 +1,336 @@
+/**
+ * 城市选择 Hook 测试
+ *
+ * 测试覆盖:
+ * - localStorage 读取已存储的城市
+ * - 首次访问时的 IP 定位
+ * - API 失败时的回退逻辑
+ * - 城市切换功能
+ * - 首次访问提示管理
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { useCitySelection } from './use-city-selection'
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key]
+    }),
+    clear: vi.fn(() => {
+      store = {}
+    }),
+    get _store() {
+      return store
+    },
+  }
+})()
+
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock,
+})
+
+// Mock fetch
+const mockFetch = vi.fn()
+global.fetch = mockFetch
+
+describe('useCitySelection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorageMock.clear()
+    // 默认 fetch 返回罗源
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ cityId: 'luoyuan' }),
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('初始化', () => {
+    it('从 localStorage 读取已存储的城市', async () => {
+      localStorageMock.setItem('selected-city', 'xiamen')
+
+      const { result } = renderHook(() => useCitySelection())
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      expect(result.current.cityId).toBe('xiamen')
+      expect(result.current.city.name).toBe('厦门')
+      // 有存储时不调用 API
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it('localStorage 中的无效城市 ID 被忽略', async () => {
+      localStorageMock.setItem('selected-city', 'invalid-city')
+
+      const { result } = renderHook(() => useCitySelection())
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      // 无效 ID 时会调用 API
+      expect(mockFetch).toHaveBeenCalledWith('/api/geo')
+    })
+
+    it('首次访问时调用 IP 定位 API', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ cityId: 'luoyuan' }),
+      })
+
+      const { result } = renderHook(() => useCitySelection())
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      expect(mockFetch).toHaveBeenCalledWith('/api/geo')
+      expect(result.current.cityId).toBe('luoyuan')
+      // 检测到的城市应存入 localStorage
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        'selected-city',
+        'luoyuan'
+      )
+    })
+
+    it('API 返回无效城市 ID 时使用默认值', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ cityId: 'unknown-city' }),
+      })
+
+      const { result } = renderHook(() => useCitySelection())
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      // 使用默认城市 (luoyuan)
+      expect(result.current.cityId).toBe('luoyuan')
+    })
+
+    it('API 失败时使用默认城市', async () => {
+      mockFetch.mockRejectedValue(new Error('Network error'))
+
+      const { result } = renderHook(() => useCitySelection())
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      // 使用默认城市
+      expect(result.current.cityId).toBe('luoyuan')
+    })
+
+    it('API 返回非 OK 状态时使用默认城市', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+      })
+
+      const { result } = renderHook(() => useCitySelection())
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      expect(result.current.cityId).toBe('luoyuan')
+    })
+  })
+
+  describe('首次访问标记', () => {
+    it('首次访问时 isFirstVisit 为 true', async () => {
+      const { result } = renderHook(() => useCitySelection())
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      expect(result.current.isFirstVisit).toBe(true)
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        'city-first-visit',
+        'true'
+      )
+    })
+
+    it('非首次访问时 isFirstVisit 为 false', async () => {
+      localStorageMock.setItem('city-first-visit', 'true')
+
+      const { result } = renderHook(() => useCitySelection())
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      expect(result.current.isFirstVisit).toBe(false)
+    })
+
+    it('dismissFirstVisitHint 清除首次访问标记', async () => {
+      const { result } = renderHook(() => useCitySelection())
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      expect(result.current.isFirstVisit).toBe(true)
+
+      act(() => {
+        result.current.dismissFirstVisitHint()
+      })
+
+      expect(result.current.isFirstVisit).toBe(false)
+    })
+  })
+
+  describe('城市切换', () => {
+    it('setCity 更新当前城市', async () => {
+      const { result } = renderHook(() => useCitySelection())
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      act(() => {
+        result.current.setCity('xiamen')
+      })
+
+      expect(result.current.cityId).toBe('xiamen')
+      expect(result.current.city.name).toBe('厦门')
+    })
+
+    it('setCity 将新城市存入 localStorage', async () => {
+      const { result } = renderHook(() => useCitySelection())
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      act(() => {
+        result.current.setCity('xiamen')
+      })
+
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        'selected-city',
+        'xiamen'
+      )
+    })
+
+    it('setCity 清除首次访问提示', async () => {
+      const { result } = renderHook(() => useCitySelection())
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      expect(result.current.isFirstVisit).toBe(true)
+
+      act(() => {
+        result.current.setCity('xiamen')
+      })
+
+      expect(result.current.isFirstVisit).toBe(false)
+    })
+  })
+
+  describe('返回值', () => {
+    it('返回所有可用城市列表', async () => {
+      const { result } = renderHook(() => useCitySelection())
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      expect(result.current.cities).toBeDefined()
+      expect(result.current.cities.length).toBeGreaterThan(0)
+      expect(result.current.cities.some((c) => c.id === 'luoyuan')).toBe(true)
+      expect(result.current.cities.some((c) => c.id === 'xiamen')).toBe(true)
+    })
+
+    it('city 对象包含完整配置', async () => {
+      const { result } = renderHook(() => useCitySelection())
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      const { city } = result.current
+      expect(city.id).toBeDefined()
+      expect(city.name).toBeDefined()
+      expect(city.adcode).toBeDefined()
+      expect(city.coordinates).toBeDefined()
+      expect(typeof city.available).toBe('boolean')
+    })
+  })
+
+  describe('用户场景模拟', () => {
+    it('新用户首次访问：IP 定位到罗源', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ cityId: 'luoyuan' }),
+      })
+
+      const { result } = renderHook(() => useCitySelection())
+
+      // 初始加载中
+      expect(result.current.isLoading).toBe(true)
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      // IP 定位成功
+      expect(result.current.cityId).toBe('luoyuan')
+      expect(result.current.isFirstVisit).toBe(true)
+    })
+
+    it('老用户再次访问：直接读取存储的城市', async () => {
+      localStorageMock.setItem('selected-city', 'xiamen')
+      localStorageMock.setItem('city-first-visit', 'true')
+
+      const { result } = renderHook(() => useCitySelection())
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      expect(result.current.cityId).toBe('xiamen')
+      expect(result.current.isFirstVisit).toBe(false)
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it('用户手动切换城市后再次访问', async () => {
+      // 模拟之前用户手动切换到厦门
+      localStorageMock.setItem('selected-city', 'xiamen')
+      localStorageMock.setItem('city-first-visit', 'true')
+
+      const { result } = renderHook(() => useCitySelection())
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      // 读取到厦门
+      expect(result.current.cityId).toBe('xiamen')
+
+      // 切换回罗源
+      act(() => {
+        result.current.setCity('luoyuan')
+      })
+
+      expect(result.current.cityId).toBe('luoyuan')
+      expect(localStorageMock._store['selected-city']).toBe('luoyuan')
+    })
+  })
+})

--- a/src/lib/city-config.test.ts
+++ b/src/lib/city-config.test.ts
@@ -1,0 +1,218 @@
+/**
+ * 城市配置测试
+ *
+ * 测试覆盖:
+ * - 城市数据完整性
+ * - 查询函数正确性
+ * - 地理定位匹配
+ * - 边界条件
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  CITIES,
+  DEFAULT_CITY_ID,
+  getCityById,
+  getCityName,
+  getCityAdcode,
+  isCityAvailable,
+  getCityByAdcode,
+  getNearestCity,
+  isValidCityId,
+  type CityId,
+} from './city-config'
+
+describe('城市配置', () => {
+  describe('CITIES 数据完整性', () => {
+    it('至少包含一个城市', () => {
+      expect(CITIES.length).toBeGreaterThan(0)
+    })
+
+    it('每个城市都有必需字段', () => {
+      CITIES.forEach((city) => {
+        expect(city.id).toBeDefined()
+        expect(city.name).toBeDefined()
+        expect(city.shortName).toBeDefined()
+        expect(city.adcode).toBeDefined()
+        expect(city.coordinates).toBeDefined()
+        expect(city.coordinates.lng).toBeDefined()
+        expect(city.coordinates.lat).toBeDefined()
+        expect(typeof city.available).toBe('boolean')
+      })
+    })
+
+    it('adcode 是 6 位数字字符串', () => {
+      CITIES.forEach((city) => {
+        expect(city.adcode).toMatch(/^\d{6}$/)
+      })
+    })
+
+    it('坐标在合理范围内（中国境内）', () => {
+      CITIES.forEach((city) => {
+        // 中国经度范围：73°33′E ~ 135°05′E
+        expect(city.coordinates.lng).toBeGreaterThan(73)
+        expect(city.coordinates.lng).toBeLessThan(136)
+        // 中国纬度范围：3°51′N ~ 53°33′N
+        expect(city.coordinates.lat).toBeGreaterThan(3)
+        expect(city.coordinates.lat).toBeLessThan(54)
+      })
+    })
+  })
+
+  describe('DEFAULT_CITY_ID', () => {
+    it('默认城市存在于 CITIES 中', () => {
+      const defaultCity = getCityById(DEFAULT_CITY_ID)
+      expect(defaultCity).toBeDefined()
+    })
+
+    it('默认城市有数据可用', () => {
+      expect(isCityAvailable(DEFAULT_CITY_ID)).toBe(true)
+    })
+  })
+
+  describe('getCityById', () => {
+    it('返回正确的城市配置', () => {
+      const luoyuan = getCityById('luoyuan')
+      expect(luoyuan?.name).toBe('罗源')
+      expect(luoyuan?.adcode).toBe('350123')
+    })
+
+    it('不存在的城市返回 undefined', () => {
+      const result = getCityById('nonexistent' as CityId)
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe('getCityName', () => {
+    it('返回城市名称', () => {
+      expect(getCityName('luoyuan')).toBe('罗源')
+      expect(getCityName('xiamen')).toBe('厦门')
+    })
+
+    it('不存在的城市返回原 ID', () => {
+      expect(getCityName('nonexistent' as CityId)).toBe('nonexistent')
+    })
+  })
+
+  describe('getCityAdcode', () => {
+    it('返回城市 adcode', () => {
+      expect(getCityAdcode('luoyuan')).toBe('350123')
+      expect(getCityAdcode('xiamen')).toBe('350200')
+    })
+
+    it('不存在的城市返回 undefined', () => {
+      expect(getCityAdcode('nonexistent' as CityId)).toBeUndefined()
+    })
+  })
+
+  describe('isCityAvailable', () => {
+    it('有数据的城市返回 true', () => {
+      expect(isCityAvailable('luoyuan')).toBe(true)
+    })
+
+    it('无数据的城市返回 false', () => {
+      expect(isCityAvailable('xiamen')).toBe(false)
+    })
+
+    it('不存在的城市返回 false', () => {
+      expect(isCityAvailable('nonexistent' as CityId)).toBe(false)
+    })
+  })
+
+  describe('getCityByAdcode', () => {
+    it('精确匹配 adcode', () => {
+      const luoyuan = getCityByAdcode('350123')
+      expect(luoyuan?.id).toBe('luoyuan')
+
+      const xiamen = getCityByAdcode('350200')
+      expect(xiamen?.id).toBe('xiamen')
+    })
+
+    it('匹配上级行政区（市级前缀）', () => {
+      // 350100 是福州市的前缀，罗源县 350123 属于福州
+      const city = getCityByAdcode('350100')
+      // 应该匹配到罗源（如果是唯一匹配）
+      expect(city).toBeDefined()
+    })
+
+    it('无匹配返回 undefined', () => {
+      const result = getCityByAdcode('999999')
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe('getNearestCity', () => {
+    it('精确坐标返回正确城市', () => {
+      // 罗源坐标
+      const luoyuanCoords = { lng: 119.549, lat: 26.489 }
+      const nearest = getNearestCity(luoyuanCoords)
+      expect(nearest.id).toBe('luoyuan')
+    })
+
+    it('厦门坐标返回厦门', () => {
+      const xiamenCoords = { lng: 118.089, lat: 24.479 }
+      const nearest = getNearestCity(xiamenCoords)
+      expect(nearest.id).toBe('xiamen')
+    })
+
+    it('中间位置返回最近的城市', () => {
+      // 在罗源和厦门之间但更接近罗源
+      const midCoords = { lng: 119.0, lat: 25.8 }
+      const nearest = getNearestCity(midCoords)
+      // 应该返回其中之一
+      expect(['luoyuan', 'xiamen']).toContain(nearest.id)
+    })
+
+    it('极端坐标不会崩溃', () => {
+      const extremeCoords = { lng: 0, lat: 0 }
+      const nearest = getNearestCity(extremeCoords)
+      expect(nearest).toBeDefined()
+      expect(nearest.id).toBeDefined()
+    })
+  })
+
+  describe('isValidCityId', () => {
+    it('有效的城市 ID 返回 true', () => {
+      expect(isValidCityId('luoyuan')).toBe(true)
+      expect(isValidCityId('xiamen')).toBe(true)
+    })
+
+    it('无效的城市 ID 返回 false', () => {
+      expect(isValidCityId('invalid')).toBe(false)
+      expect(isValidCityId('')).toBe(false)
+      expect(isValidCityId('LUOYUAN')).toBe(false) // 大小写敏感
+    })
+  })
+
+  describe('用户场景模拟', () => {
+    it('用户首次访问：使用默认城市', () => {
+      const defaultCity = getCityById(DEFAULT_CITY_ID)
+      expect(defaultCity).toBeDefined()
+      expect(isCityAvailable(defaultCity!.id)).toBe(true)
+    })
+
+    it('IP 定位返回 adcode：匹配城市', () => {
+      // 模拟 IP 定位 API 返回福州市的 adcode
+      const ipAdcode = '350100' // 福州市
+      const city = getCityByAdcode(ipAdcode)
+      expect(city).toBeDefined()
+    })
+
+    it('GPS 定位：返回最近城市', () => {
+      // 用户在罗源附近
+      const userLocation = { lng: 119.55, lat: 26.48 }
+      const nearestCity = getNearestCity(userLocation)
+      expect(nearestCity.id).toBe('luoyuan')
+    })
+
+    it('用户选择城市后验证', () => {
+      const selectedCityId = 'xiamen'
+      expect(isValidCityId(selectedCityId)).toBe(true)
+
+      const cityConfig = getCityById(selectedCityId as CityId)
+      expect(cityConfig?.name).toBe('厦门')
+
+      // 厦门目前无数据
+      expect(isCityAvailable(selectedCityId as CityId)).toBe(false)
+    })
+  })
+})

--- a/src/lib/pinyin-utils.test.ts
+++ b/src/lib/pinyin-utils.test.ts
@@ -1,0 +1,195 @@
+/**
+ * 拼音搜索工具函数测试
+ *
+ * 测试覆盖:
+ * - 中文检测
+ * - 拼音检测
+ * - 拼音匹配（全拼、首字母）
+ * - 边界条件
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  containsChinese,
+  isPinyin,
+  matchPinyin,
+  getPinyinMatchPosition,
+} from './pinyin-utils'
+
+// Mock pinyin-pro 的 match 函数
+vi.mock('pinyin-pro', () => ({
+  match: vi.fn((text: string, query: string) => {
+    // 模拟 pinyin-pro 的匹配行为
+    // 简化实现：检测首字母匹配
+    const mockMatches: Record<string, Record<string, number[]>> = {
+      '年年有鱼': {
+        'nnyyú': [0, 1, 2, 3],
+        'nnyy': [0, 1, 2, 3],
+        'nn': [0, 1],
+        'yu': [3],
+      },
+      '鱼尔': {
+        'yu': [0],
+        'ye': [0, 1],
+        'yuer': [0, 1],
+      },
+      '虎纠鱼丸': {
+        'hj': [0, 1],
+        'hjyw': [0, 1, 2, 3],
+        'yu': [2],
+      },
+      '蟹黄堡': {
+        'xhb': [0, 1, 2],
+        'xie': [0],
+      },
+    }
+    return mockMatches[text]?.[query.toLowerCase()] ?? null
+  }),
+}))
+
+describe('拼音搜索工具', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('containsChinese', () => {
+    it('检测纯中文字符串', () => {
+      expect(containsChinese('鱼尔')).toBe(true)
+      expect(containsChinese('年年有鱼')).toBe(true)
+      expect(containsChinese('蟹黄堡')).toBe(true)
+    })
+
+    it('检测中英混合字符串', () => {
+      expect(containsChinese('V3线路')).toBe(true)
+      expect(containsChinese('hello世界')).toBe(true)
+    })
+
+    it('检测纯英文字符串', () => {
+      expect(containsChinese('hello')).toBe(false)
+      expect(containsChinese('pinyin')).toBe(false)
+      expect(containsChinese('V3')).toBe(false)
+    })
+
+    it('检测空字符串', () => {
+      expect(containsChinese('')).toBe(false)
+    })
+
+    it('检测特殊字符', () => {
+      expect(containsChinese('!@#$%')).toBe(false)
+      expect(containsChinese('123')).toBe(false)
+    })
+  })
+
+  describe('isPinyin', () => {
+    it('检测纯字母字符串', () => {
+      expect(isPinyin('pinyin')).toBe(true)
+      expect(isPinyin('yu')).toBe(true)
+      expect(isPinyin('NNYY')).toBe(true)
+      expect(isPinyin('xhb')).toBe(true)
+    })
+
+    it('检测包含数字的字符串', () => {
+      expect(isPinyin('v3')).toBe(false)
+      expect(isPinyin('123')).toBe(false)
+    })
+
+    it('检测包含中文的字符串', () => {
+      expect(isPinyin('鱼')).toBe(false)
+      expect(isPinyin('yu鱼')).toBe(false)
+    })
+
+    it('检测包含特殊字符的字符串', () => {
+      expect(isPinyin('pin-yin')).toBe(false)
+      expect(isPinyin('pin yin')).toBe(false)
+      expect(isPinyin("pin'yin")).toBe(false)
+    })
+
+    it('检测空字符串', () => {
+      expect(isPinyin('')).toBe(false)
+    })
+  })
+
+  describe('matchPinyin', () => {
+    it('匹配全拼', () => {
+      const result = matchPinyin('鱼尔', 'yuer')
+      expect(result).toEqual([0, 1])
+    })
+
+    it('匹配首字母', () => {
+      const result = matchPinyin('蟹黄堡', 'xhb')
+      expect(result).toEqual([0, 1, 2])
+    })
+
+    it('匹配部分拼音', () => {
+      const result = matchPinyin('年年有鱼', 'nn')
+      expect(result).toEqual([0, 1])
+    })
+
+    it('查询包含中文时返回 null（使用原生匹配）', () => {
+      const result = matchPinyin('鱼尔', '鱼')
+      expect(result).toBeNull()
+    })
+
+    it('空文本返回 null', () => {
+      expect(matchPinyin('', 'yu')).toBeNull()
+    })
+
+    it('空查询返回 null', () => {
+      expect(matchPinyin('鱼尔', '')).toBeNull()
+    })
+
+    it('无匹配结果返回 null', () => {
+      const result = matchPinyin('鱼尔', 'abc')
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('getPinyinMatchPosition', () => {
+    it('返回首个匹配位置', () => {
+      expect(getPinyinMatchPosition('鱼尔', 'yu')).toBe(0)
+      expect(getPinyinMatchPosition('虎纠鱼丸', 'yu')).toBe(2)
+    })
+
+    it('无匹配时返回 -1', () => {
+      expect(getPinyinMatchPosition('鱼尔', 'abc')).toBe(-1)
+    })
+
+    it('空输入返回 -1', () => {
+      expect(getPinyinMatchPosition('', 'yu')).toBe(-1)
+      expect(getPinyinMatchPosition('鱼尔', '')).toBe(-1)
+    })
+
+    it('中文查询返回 -1（不使用拼音匹配）', () => {
+      expect(getPinyinMatchPosition('鱼尔', '鱼')).toBe(-1)
+    })
+  })
+
+  describe('搜索场景模拟', () => {
+    const routes = ['年年有鱼', '鱼尔', '虎纠鱼丸', '蟹黄堡']
+
+    it('拼音搜索 "yu" 能匹配多个线路', () => {
+      const matches = routes.filter((route) => matchPinyin(route, 'yu') !== null)
+      expect(matches).toContain('年年有鱼')
+      expect(matches).toContain('鱼尔')
+      expect(matches).toContain('虎纠鱼丸')
+      expect(matches).not.toContain('蟹黄堡')
+    })
+
+    it('首字母搜索 "xhb" 能精确匹配', () => {
+      const matches = routes.filter((route) => matchPinyin(route, 'xhb') !== null)
+      expect(matches).toEqual(['蟹黄堡'])
+    })
+
+    it('搜索结果按匹配位置排序', () => {
+      const results = routes
+        .map((route) => ({
+          name: route,
+          position: getPinyinMatchPosition(route, 'yu'),
+        }))
+        .filter((r) => r.position >= 0)
+        .sort((a, b) => a.position - b.position)
+
+      // 鱼尔 position=0 应该排第一
+      expect(results[0].name).toBe('鱼尔')
+    })
+  })
+})

--- a/src/lib/weather-utils.test.ts
+++ b/src/lib/weather-utils.test.ts
@@ -1,0 +1,271 @@
+/**
+ * 天气工具函数测试
+ *
+ * 测试覆盖:
+ * - 攀岩适宜度评估
+ * - 日期格式化
+ * - 适宜度图标
+ * - 边界条件
+ */
+import { describe, it, expect } from 'vitest'
+import type { WeatherLive } from '@/types'
+import {
+  evaluateClimbingCondition,
+  formatWeekday,
+  formatShortDate,
+  isToday,
+  getSuitabilityIcon,
+} from './weather-utils'
+
+// 创建模拟天气数据的辅助函数
+function createMockWeather(overrides: Partial<WeatherLive> = {}): WeatherLive {
+  return {
+    weather: '晴',
+    temperature: 22,
+    humidity: 55,
+    windDirection: '东南风',
+    windPower: '2',
+    reportTime: '2025-01-19 10:00:00',
+    ...overrides,
+  }
+}
+
+describe('天气工具函数', () => {
+  describe('evaluateClimbingCondition', () => {
+    describe('恶劣天气判定', () => {
+      it('雨天直接判定为 poor', () => {
+        const weather = createMockWeather({ weather: '小雨' })
+        const result = evaluateClimbingCondition(weather)
+        expect(result.level).toBe('poor')
+        expect(result.factors).toContain('天气: 小雨')
+      })
+
+      it('雷暴天气判定为 poor', () => {
+        const weather = createMockWeather({ weather: '雷阵雨' })
+        const result = evaluateClimbingCondition(weather)
+        expect(result.level).toBe('poor')
+      })
+
+      it('暴风天气判定为 poor', () => {
+        // 注意：'大风' 不在恶劣天气关键词中，强风通过 windPower 字段判断
+        // 这里测试的是天气字符串包含 '暴' 或 '风暴' 的情况
+        const weather = createMockWeather({ weather: '暴风' })
+        const result = evaluateClimbingCondition(weather)
+        expect(result.level).toBe('poor')
+      })
+
+      it('雪天判定为 poor', () => {
+        const weather = createMockWeather({ weather: '小雪' })
+        const result = evaluateClimbingCondition(weather)
+        expect(result.level).toBe('poor')
+      })
+    })
+
+    describe('理想天气判定', () => {
+      it('晴天 + 理想温湿度 = excellent', () => {
+        const weather = createMockWeather({
+          weather: '晴',
+          temperature: 20,
+          humidity: 50,
+          windPower: '1',
+        })
+        const result = evaluateClimbingCondition(weather)
+        expect(result.level).toBe('excellent')
+        expect(result.factors).toContain('天气: 晴 ✓')
+      })
+
+      it('多云天气也是理想天气', () => {
+        const weather = createMockWeather({
+          weather: '多云',
+          temperature: 18,
+          humidity: 55,
+          windPower: '2',
+        })
+        const result = evaluateClimbingCondition(weather)
+        expect(result.level).toBe('excellent')
+      })
+    })
+
+    describe('温度评估', () => {
+      it('极低温度判定为 poor', () => {
+        const weather = createMockWeather({ temperature: 0 })
+        const result = evaluateClimbingCondition(weather)
+        expect(result.level).toBe('poor')
+        expect(result.factors.some((f) => f.includes('温度偏低'))).toBe(true)
+      })
+
+      it('极高温度判定为 poor', () => {
+        const weather = createMockWeather({ temperature: 40 })
+        const result = evaluateClimbingCondition(weather)
+        expect(result.level).toBe('poor')
+        expect(result.factors.some((f) => f.includes('温度偏高'))).toBe(true)
+      })
+
+      it('适中温度判定为 good 或 excellent', () => {
+        const weather = createMockWeather({ temperature: 22 })
+        const result = evaluateClimbingCondition(weather)
+        expect(['excellent', 'good']).toContain(result.level)
+      })
+    })
+
+    describe('湿度评估', () => {
+      it('超高湿度 (>85%) 判定为 poor', () => {
+        const weather = createMockWeather({ humidity: 90 })
+        const result = evaluateClimbingCondition(weather)
+        expect(result.level).toBe('poor')
+        expect(result.factors.some((f) => f.includes('湿度过高'))).toBe(true)
+      })
+
+      it('极低湿度有提示', () => {
+        const weather = createMockWeather({ humidity: 20 })
+        const result = evaluateClimbingCondition(weather)
+        // 低湿度可能是 fair，取决于其他因素
+        expect(result.factors.some((f) => f.includes('湿度'))).toBe(true)
+      })
+    })
+
+    describe('风力评估', () => {
+      it('强风 (6级以上) 判定为 poor', () => {
+        const weather = createMockWeather({ windPower: '7' })
+        const result = evaluateClimbingCondition(weather)
+        expect(result.level).toBe('poor')
+      })
+
+      it('中等风力有提示', () => {
+        const weather = createMockWeather({ windPower: '4' })
+        const result = evaluateClimbingCondition(weather)
+        expect(result.factors.some((f) => f.includes('风力'))).toBe(true)
+      })
+
+      it('微风无提示', () => {
+        const weather = createMockWeather({ windPower: '1' })
+        const result = evaluateClimbingCondition(weather)
+        expect(result.factors.some((f) => f.includes('风力'))).toBe(false)
+      })
+    })
+
+    describe('综合评估', () => {
+      it('返回完整的评估结构', () => {
+        const weather = createMockWeather()
+        const result = evaluateClimbingCondition(weather)
+
+        expect(result).toHaveProperty('level')
+        expect(result).toHaveProperty('label')
+        expect(result).toHaveProperty('description')
+        expect(result).toHaveProperty('factors')
+        expect(Array.isArray(result.factors)).toBe(true)
+      })
+
+      it('多个不良因素取最差等级', () => {
+        const weather = createMockWeather({
+          weather: '阴',
+          temperature: 35, // 偏高
+          humidity: 80, // 偏高
+          windPower: '4', // 中等
+        })
+        const result = evaluateClimbingCondition(weather)
+        // 应该是较差的等级
+        expect(['fair', 'poor']).toContain(result.level)
+      })
+    })
+  })
+
+  describe('formatWeekday', () => {
+    it('正确转换数字为中文星期', () => {
+      expect(formatWeekday('1')).toBe('周一')
+      expect(formatWeekday('2')).toBe('周二')
+      expect(formatWeekday('3')).toBe('周三')
+      expect(formatWeekday('4')).toBe('周四')
+      expect(formatWeekday('5')).toBe('周五')
+      expect(formatWeekday('6')).toBe('周六')
+      expect(formatWeekday('7')).toBe('周日')
+    })
+
+    it('无效输入返回原值', () => {
+      expect(formatWeekday('0')).toBe('0')
+      expect(formatWeekday('8')).toBe('8')
+      expect(formatWeekday('abc')).toBe('abc')
+    })
+  })
+
+  describe('formatShortDate', () => {
+    it('正确格式化日期', () => {
+      expect(formatShortDate('2025-01-19')).toBe('01/19')
+      expect(formatShortDate('2025-12-31')).toBe('12/31')
+      expect(formatShortDate('2025-06-05')).toBe('06/05')
+    })
+
+    it('无效格式返回原值', () => {
+      expect(formatShortDate('20250119')).toBe('20250119')
+      expect(formatShortDate('01-19')).toBe('01-19')
+      expect(formatShortDate('')).toBe('')
+    })
+  })
+
+  describe('isToday', () => {
+    it('判断今天的日期', () => {
+      const today = new Date().toISOString().split('T')[0]
+      expect(isToday(today)).toBe(true)
+    })
+
+    it('判断昨天的日期', () => {
+      const yesterday = new Date()
+      yesterday.setDate(yesterday.getDate() - 1)
+      const yesterdayStr = yesterday.toISOString().split('T')[0]
+      expect(isToday(yesterdayStr)).toBe(false)
+    })
+
+    it('判断明天的日期', () => {
+      const tomorrow = new Date()
+      tomorrow.setDate(tomorrow.getDate() + 1)
+      const tomorrowStr = tomorrow.toISOString().split('T')[0]
+      expect(isToday(tomorrowStr)).toBe(false)
+    })
+  })
+
+  describe('getSuitabilityIcon', () => {
+    it('返回正确的图标', () => {
+      expect(getSuitabilityIcon('excellent')).toBe('🟢')
+      expect(getSuitabilityIcon('good')).toBe('🔵')
+      expect(getSuitabilityIcon('fair')).toBe('🟡')
+      expect(getSuitabilityIcon('poor')).toBe('🔴')
+    })
+  })
+
+  describe('攀岩场景模拟', () => {
+    it('完美攀岩天：晴朗、18°C、50%湿度、微风', () => {
+      const weather = createMockWeather({
+        weather: '晴',
+        temperature: 18,
+        humidity: 50,
+        windPower: '1',
+      })
+      const result = evaluateClimbingCondition(weather)
+      expect(result.level).toBe('excellent')
+      expect(result.description).toContain('完美')
+    })
+
+    it('可以攀岩但不太理想：阴天、28°C、70%湿度', () => {
+      const weather = createMockWeather({
+        weather: '阴',
+        temperature: 28,
+        humidity: 70,
+        windPower: '2',
+      })
+      const result = evaluateClimbingCondition(weather)
+      expect(['good', 'fair']).toContain(result.level)
+    })
+
+    it('不建议攀岩：雨天', () => {
+      const weather = createMockWeather({
+        weather: '中雨',
+        temperature: 20,
+        humidity: 85,
+        windPower: '3',
+      })
+      const result = evaluateClimbingCondition(weather)
+      expect(result.level).toBe('poor')
+      expect(result.description).toContain('不适合')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- 为核心 UX 模块添加全面的单元测试覆盖
- 测试覆盖率从 ~25% 提升至 **38.4%** (+13.4%)

## 新增测试文件
| 文件 | 测试数 | 覆盖率 |
|------|-------|--------|
| `pinyin-utils.test.ts` | 24 | 100% |
| `weather-utils.test.ts` | 27 | 95.34% |
| `city-config.test.ts` | 28 | 100% |
| `theme-switcher.test.tsx` | 16 | 96.29% |
| `use-city-selection.test.ts` | 17 | 100% |

## 测试覆盖场景
- **拼音搜索**: 中文检测、全拼/首字母匹配、搜索排序
- **天气评估**: 恶劣天气判定、温湿度评估、攀岩适宜度计算
- **城市配置**: 数据完整性、adcode 匹配、最近城市查询
- **主题切换器**: 渲染、选中态、点击交互、自动模式提示
- **城市选择 Hook**: localStorage 持久化、IP 定位、首次访问标记

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)