### PR TITLE
refactor: extract desktop centering into reusable CSS utilities

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -55,6 +55,10 @@
   --theme-transition: color 0.2s ease, background-color 0.2s ease,
                       border-color 0.2s ease, box-shadow 0.2s ease;
 
+  /* Design Tokens - App Shell (桌面端容器) */
+  --app-shell-width: 480px;
+  --app-shell-padding: 16px; /* 内边距，用于计算内容区宽度 */
+
   /* Design Tokens - Spacing */
   --space-xs: 0.25rem;
   --space-sm: 0.5rem;
@@ -334,4 +338,37 @@
 
 .animate-fade-in {
   animation: fade-in 0.2s ease-out forwards;
+}
+
+/* ==================== 桌面端适配工具类 ==================== */
+
+/**
+ * 桌面端居中容器
+ * 移动端：全宽
+ * 桌面端 (≥768px)：居中 + 固定宽度
+ */
+.desktop-center-full {
+  /* 桌面端：居中并限制为容器宽度 */
+  @media (min-width: 768px) {
+    left: 50% !important;
+    right: auto !important;
+    transform: translateX(-50%);
+    max-width: var(--app-shell-width);
+    width: 100%;
+  }
+}
+
+/**
+ * 桌面端居中容器（带内边距）
+ * 用于需要保留左右边距的固定元素（如搜索框、提示框）
+ * 内容宽度 = 容器宽度 - 2 * padding
+ */
+.desktop-center-padded {
+  @media (min-width: 768px) {
+    left: 50% !important;
+    right: auto !important;
+    transform: translateX(-50%);
+    max-width: calc(var(--app-shell-width) - var(--app-shell-padding) * 2);
+    width: 100%;
+  }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -66,8 +66,8 @@ export default function RootLayout({
             {/* 居中容器 - 移动端全宽，桌面端固定宽度居中 + 阴影 */}
             <div
               id="app-shell"
-              className="relative mx-auto w-full max-w-[480px] min-h-screen md:shadow-2xl"
-              style={{ backgroundColor: "var(--theme-surface)" }}
+              className="relative mx-auto w-full min-h-screen md:shadow-2xl"
+              style={{ maxWidth: "var(--app-shell-width)", backgroundColor: "var(--theme-surface)" }}
             >
               <OfflineIndicator />
               {children}

--- a/src/components/app-tabbar.tsx
+++ b/src/components/app-tabbar.tsx
@@ -20,7 +20,7 @@ export function AppTabbar() {
 
   return (
     <nav
-      className="fixed bottom-0 left-0 right-0 md:left-1/2 md:-translate-x-1/2 md:max-w-[480px] backdrop-blur-xl safe-area-bottom z-50"
+      className="fixed bottom-0 left-0 right-0 desktop-center-full backdrop-blur-xl safe-area-bottom z-50"
       style={{
         backgroundColor: 'color-mix(in srgb, var(--theme-surface) 80%, transparent)',
         borderTop: '1px solid color-mix(in srgb, var(--theme-outline) 30%, transparent)',

--- a/src/components/floating-search.tsx
+++ b/src/components/floating-search.tsx
@@ -12,7 +12,7 @@ export function FloatingSearch({
   placeholder = '搜索线路，支持拼音如 yts',
 }: FloatingSearchProps) {
   return (
-    <div className="fixed bottom-20 left-4 right-4 md:left-1/2 md:-translate-x-1/2 md:max-w-[448px] md:w-full z-40">
+    <div className="fixed bottom-20 left-4 right-4 desktop-center-padded z-40">
       <button
         onClick={onClick}
         className="w-full h-12 flex items-center gap-3 px-4 active:scale-[0.98]"

--- a/src/components/offline-indicator.tsx
+++ b/src/components/offline-indicator.tsx
@@ -27,7 +27,7 @@ export default function OfflineIndicator() {
 
   return (
     <div
-      className="fixed top-0 left-0 right-0 md:left-1/2 md:-translate-x-1/2 md:max-w-[480px] z-50 px-4 py-2 flex items-center justify-center gap-2 animate-fade-in-up"
+      className="fixed top-0 left-0 right-0 desktop-center-full z-50 px-4 py-2 flex items-center justify-center gap-2 animate-fade-in-up"
       style={{
         backgroundColor: 'var(--theme-warning)',
         color: 'white',

--- a/src/components/sw-update-prompt.tsx
+++ b/src/components/sw-update-prompt.tsx
@@ -57,7 +57,7 @@ export default function SWUpdatePrompt() {
 
   return (
     <div
-      className="fixed bottom-20 left-4 right-4 md:left-1/2 md:-translate-x-1/2 md:max-w-[448px] md:w-full z-50 p-4 animate-fade-in-up"
+      className="fixed bottom-20 left-4 right-4 desktop-center-padded z-50 p-4 animate-fade-in-up"
       style={{
         backgroundColor: 'var(--theme-primary)',
         color: 'var(--theme-on-primary)',


### PR DESCRIPTION
## Summary
- Add `--app-shell-width` and `--app-shell-padding` CSS variables for centralized configuration
- Create `.desktop-center-full` utility class for full-width fixed elements (TabBar, Offline indicator)
- Create `.desktop-center-padded` utility class for padded fixed elements (Search, Update prompt)
- Refactor 4 components to use new utilities, eliminating repeated inline Tailwind classes

## Related
Follow-up improvement to #30 / PR #31

## Test plan
- [x] ESLint passes
- [x] TypeScript type check passes
- [x] Production build succeeds
- [ ] Visual verification in desktop browser

🤖 Generated with [Claude Code](https://claude.ai/code)