### PR TITLE
chore: 图片存储从腾讯云 COS 迁移到 Cloudflare R2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -464,8 +464,8 @@ import AMapContainer from '@/components/amap-container'
 
 - Service Worker: `src/app/sw.ts` (Serwist)
 - Manifest: `public/manifest.json`
-- COS 图片缓存 30 天，最多 200 张
-- 图片域名: `topo-image-1305178596.cos.ap-guangzhou.myqcloud.com`
+- R2 图片缓存 30 天，最多 200 张
+- 图片域名: `img.bouldering.top` (Cloudflare R2)
 
 ## API Routes
 

--- a/doc/PROJECT_OVERVIEW.md
+++ b/doc/PROJECT_OVERVIEW.md
@@ -470,7 +470,7 @@ images: {
   remotePatterns: [
     {
       protocol: "https",
-      hostname: "topo-image-1305178596.cos.ap-guangzhou.myqcloud.com"
+      hostname: "img.bouldering.top"
     }
   ],
   formats: ["image/avif", "image/webp"]  // 现代格式
@@ -480,7 +480,7 @@ images: {
 ### 9.3 缓存策略
 
 - **HTML/JS/CSS**: defaultCache (Serwist)
-- **COS 图片**: CacheFirst 30 天，最多 200 张
+- **R2 图片**: CacheFirst 30 天，最多 200 张
 - **浏览器缓存**: 由 CDN 配置 (public 资源)
 
 ---

--- a/next.config.ts
+++ b/next.config.ts
@@ -16,7 +16,7 @@ const nextConfig: NextConfig = {
     remotePatterns: [
       {
         protocol: "https",
-        hostname: "topo-image-1305178596.cos.ap-guangzhou.myqcloud.com",
+        hostname: "img.bouldering.top",
       },
     ],
     formats: ["image/avif", "image/webp"],
@@ -51,7 +51,7 @@ const nextConfig: NextConfig = {
               "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
               "img-src 'self' data: https: blob:",
               "font-src 'self' https://fonts.gstatic.com",
-              "connect-src 'self' https://topo-image-1305178596.cos.ap-guangzhou.myqcloud.com https://restapi.amap.com https://*.amap.com https://*.is.autonavi.com",
+              "connect-src 'self' https://img.bouldering.top https://restapi.amap.com https://*.amap.com https://*.is.autonavi.com",
               "frame-ancestors 'none'",
               "base-uri 'self'",
               "form-action 'self'",

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -12,8 +12,8 @@ import { ImageViewer } from '@/components/ui/image-viewer'
 const AUTHOR = {
   name: '傅文杰',
   bio: '爱攀岩的程序猿 🧗‍♂️',
-  avatarUrl: 'https://topo-image-1305178596.cos.ap-guangzhou.myqcloud.com/avatar.jpg',
-  donateUrl: 'https://topo-image-1305178596.cos.ap-guangzhou.myqcloud.com/donate.png',
+  avatarUrl: 'https://img.bouldering.top/avatar.jpg',
+  donateUrl: 'https://img.bouldering.top/donate.png',
   wechat: 'Novmbrain',
   xiaohongshu: 'WindOfBretagne',
 }

--- a/src/app/sw.ts
+++ b/src/app/sw.ts
@@ -11,11 +11,11 @@ declare global {
 
 declare const self: ServiceWorkerGlobalScope;
 
-// COS 图片缓存策略 - 优先使用缓存
-const cosImageCache: RuntimeCaching = {
-  matcher: ({ url }) => url.hostname === "topo-image-1305178596.cos.ap-guangzhou.myqcloud.com",
+// R2 图片缓存策略 - 优先使用缓存
+const r2ImageCache: RuntimeCaching = {
+  matcher: ({ url }) => url.hostname === "img.bouldering.top",
   handler: new CacheFirst({
-    cacheName: "cos-images",
+    cacheName: "r2-images",
     plugins: [
       new ExpirationPlugin({
         maxEntries: SW_CACHE.COS_IMAGES.maxEntries,
@@ -31,7 +31,7 @@ const serwist = new Serwist({
   skipWaiting: true,
   clientsClaim: true,
   navigationPreload: true,
-  runtimeCaching: [cosImageCache, ...defaultCache],
+  runtimeCaching: [r2ImageCache, ...defaultCache],
 });
 
 serwist.addEventListeners();

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,18 +1,18 @@
 /**
- * 腾讯云 COS 图片存储配置
+ * Cloudflare R2 图片存储配置
  */
-const COS_BASE_URL = 'https://topo-image-1305178596.cos.ap-guangzhou.myqcloud.com'
+const IMAGE_BASE_URL = 'https://img.bouldering.top'
 
 /**
  * 生成线路 TOPO 图片 URL
  */
 export function getRouteTopoUrl(cragId: string, routeName: string): string {
-  return `${COS_BASE_URL}/${cragId}/${encodeURIComponent(routeName)}.jpg`
+  return `${IMAGE_BASE_URL}/${cragId}/${encodeURIComponent(routeName)}.jpg`
 }
 
 /**
  * 生成岩场封面图片 URL
  */
 export function getCragCoverUrl(cragId: string, index: number): string {
-  return `${COS_BASE_URL}/CragSurface/${cragId}/${index}.jpg`
+  return `${IMAGE_BASE_URL}/CragSurface/${cragId}/${index}.jpg`
 }


### PR DESCRIPTION
## Summary

- 将图片存储从腾讯云 COS 迁移到 Cloudflare R2
- 新图片域名：`img.bouldering.top`
- 实现统一架构（域名、CDN、存储都在 Cloudflare）

## Changes

| 文件 | 修改内容 |
|------|---------|
| `src/lib/constants.ts` | `COS_BASE_URL` → `IMAGE_BASE_URL` |
| `next.config.ts` | 更新 `remotePatterns` 和 CSP |
| `src/app/sw.ts` | 更新 Service Worker 缓存匹配 |
| `src/app/profile/page.tsx` | 更新头像和打赏码 URL |
| `CLAUDE.md` | 更新文档 |
| `doc/PROJECT_OVERVIEW.md` | 更新文档 |

## Benefits

- ✅ 零出口费用（R2 不收取流量费）
- ✅ 统一管理（域名、CDN、存储都在 Cloudflare）
- ✅ 更好的缓存控制

## Test plan

- [ ] 访问首页检查岩场封面图片
- [ ] 访问线路详情检查 TOPO 图片
- [ ] 访问个人页面检查头像和打赏码

Closes #36

🤖 Generated with [Claude Code](https://claude.ai/claude-code)