### PR TITLE
feat: 图片缓存优化 - 版本号机制 + 1年 TTL

### DIFF
--- a/src/app/sw.ts
+++ b/src/app/sw.ts
@@ -18,8 +18,8 @@ const r2ImageCache: RuntimeCaching = {
     cacheName: "r2-images",
     plugins: [
       new ExpirationPlugin({
-        maxEntries: SW_CACHE.COS_IMAGES.maxEntries,
-        maxAgeSeconds: SW_CACHE.COS_IMAGES.maxAgeSeconds,
+        maxEntries: SW_CACHE.R2_IMAGES.maxEntries,
+        maxAgeSeconds: SW_CACHE.R2_IMAGES.maxAgeSeconds,
         purgeOnQuotaError: true,
       }),
     ],

--- a/src/lib/cache-config.ts
+++ b/src/lib/cache-config.ts
@@ -19,6 +19,7 @@ export const SECONDS = {
   DAY: 60 * 60 * 24,
   WEEK: 60 * 60 * 24 * 7,
   MONTH: 60 * 60 * 24 * 30,
+  YEAR: 60 * 60 * 24 * 365,
 } as const
 
 /** 毫秒级时间单位 - 用于 API 内存缓存、setTimeout 等 */
@@ -62,12 +63,12 @@ export const ISR_REVALIDATE = {
  * 使用场景: Serwist ExpirationPlugin
  */
 export const SW_CACHE = {
-  /** COS 图片缓存配置 */
-  COS_IMAGES: {
+  /** R2 图片缓存配置 */
+  R2_IMAGES: {
     /** 最大缓存条目数 */
     maxEntries: 200,
-    /** 缓存过期时间 (秒) */
-    maxAgeSeconds: 30 * SECONDS.DAY, // 30 天
+    /** 缓存过期时间 (秒) - 有版本号可随时刷新，设置为 1 年 */
+    maxAgeSeconds: SECONDS.YEAR, // 1 年 (31536000 秒)
   },
 } as const
 
@@ -80,8 +81,8 @@ export const SW_CACHE = {
  * 使用场景: next.config.ts images.minimumCacheTTL
  */
 export const IMAGE_CACHE = {
-  /** 远程图片最小缓存时间 */
-  MINIMUM_TTL: SECONDS.MONTH, // 1 个月
+  /** 远程图片最小缓存时间 - 有版本号可随时刷新，设置为 1 年 */
+  MINIMUM_TTL: SECONDS.YEAR, // 1 年 (31536000 秒)
 } as const
 
 // ==================== API 内存缓存配置 ====================

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -4,15 +4,28 @@
 const IMAGE_BASE_URL = 'https://img.bouldering.top'
 
 /**
- * 生成线路 TOPO 图片 URL
+ * 图片全局版本号 (Cache Busting)
+ *
+ * 当批量更新图片后，修改此值即可让所有用户获取新图片
+ * 格式建议：YYYYMMDD 或递增数字
+ *
+ * 示例：
+ * - 初始版本：'1'
+ * - 2025年1月更新：'20250120'
+ * - 下次更新：'20250215'
+ */
+export const IMAGE_VERSION = '1'
+
+/**
+ * 生成线路 TOPO 图片 URL (带版本号)
  */
 export function getRouteTopoUrl(cragId: string, routeName: string): string {
-  return `${IMAGE_BASE_URL}/${cragId}/${encodeURIComponent(routeName)}.jpg`
+  return `${IMAGE_BASE_URL}/${cragId}/${encodeURIComponent(routeName)}.jpg?v=${IMAGE_VERSION}`
 }
 
 /**
- * 生成岩场封面图片 URL
+ * 生成岩场封面图片 URL (带版本号)
  */
 export function getCragCoverUrl(cragId: string, index: number): string {
-  return `${IMAGE_BASE_URL}/CragSurface/${cragId}/${index}.jpg`
+  return `${IMAGE_BASE_URL}/CragSurface/${cragId}/${index}.jpg?v=${IMAGE_VERSION}`
 }


### PR DESCRIPTION
## Summary

- 添加图片版本号机制 (Cache Busting)
- 延长图片缓存 TTL 从 30 天到 1 年

## Changes

| 文件 | 修改内容 |
|------|---------|
| `src/lib/constants.ts` | 添加 `IMAGE_VERSION`，URL 加 `?v=` 参数 |
| `src/lib/cache-config.ts` | 添加 `SECONDS.YEAR`，TTL 改为 1 年 |
| `src/app/sw.ts` | 引用更新为 `R2_IMAGES` |

## How It Works

```
更新图片时：
1. 上传新图片到 R2（覆盖原文件）
2. 修改 IMAGE_VERSION = '20250120' → '20250215'
3. 部署 → 用户获取新 URL → 绕过缓存 → 加载新图片
```

## Test plan

- [ ] 验证图片 URL 包含 `?v=1` 参数
- [ ] 验证 Service Worker 缓存正常工作

Closes #38

🤖 Generated with [Claude Code](https://claude.ai/claude-code)