### PR TITLE
fix: 桌面端 UI 适配问题

### DIFF
--- a/src/app/crag/[id]/crag-detail-client.tsx
+++ b/src/app/crag/[id]/crag-detail-client.tsx
@@ -223,7 +223,7 @@ export default function CragDetailClient({ crag, routes }: CragDetailClientProps
 
       {/* 底部操作按钮 */}
       <div
-        className="fixed bottom-0 left-0 right-0 p-4"
+        className="fixed bottom-0 left-0 right-0 desktop-center-padded p-4"
         style={{ background: `linear-gradient(to top, var(--theme-surface), transparent)` }}
       >
         <Button

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -196,7 +196,7 @@ export function Drawer({
       {/* 抽屉主体 */}
       <div
         ref={drawerRef}
-        className={`absolute bottom-0 left-0 right-0 overflow-hidden flex flex-col ${
+        className={`absolute bottom-0 left-0 right-0 desktop-center-full overflow-hidden flex flex-col ${
           isClosing ? '' : 'animate-drawer-in'
         }`}
         style={{


### PR DESCRIPTION
## Summary

修复桌面端两个 UI 显示问题：

1. **岩场详情页按钮占满屏幕** → 添加 `desktop-center-padded`
2. **线路详情抽屉图片比例异常** → 添加 `desktop-center-full`

## Changes

| 文件 | 修改 |
|------|------|
| `src/app/crag/[id]/crag-detail-client.tsx` | 底部按钮添加桌面端居中 |
| `src/components/ui/drawer.tsx` | 抽屉组件添加桌面端居中 |

## Mobile Safety

这些类使用媒体查询，**不影响手机端**：

```css
@media (min-width: 768px) {
  /* 只在桌面端生效 */
}
```

## Test plan

- [ ] 手机端：验证布局无变化
- [ ] 桌面端：验证按钮和抽屉居中显示

Closes #40

🤖 Generated with [Claude Code](https://claude.ai/claude-code)