### PR TITLE
fix: 修复桌面端抽屉组件位置偏移 (Transform 冲突)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -349,10 +349,12 @@
  */
 .desktop-center-full {
   /* 桌面端：居中并限制为容器宽度 */
+  /* 使用 margin: auto 而非 transform，避免与组件动画的 transform 冲突 */
   @media (min-width: 768px) {
-    left: 50% !important;
-    right: auto !important;
-    transform: translateX(-50%);
+    left: 0 !important;
+    right: 0 !important;
+    margin-left: auto !important;
+    margin-right: auto !important;
     max-width: var(--app-shell-width);
     width: 100%;
   }


### PR DESCRIPTION
## Summary

- 修复桌面端抽屉组件位置偏移问题
- 将 `desktop-center-full` 类的居中方式从 `transform: translateX(-50%)` 改为 `margin: auto`

## 问题原因

CSS `transform` 属性只能有一个值。当 Drawer 组件的 JS 动画设置 `transform: translateY()` 时，会覆盖 CSS 中的 `transform: translateX(-50%)`，导致水平居中失效。

## 解决方案

```css
/* 修改前 */
.desktop-center-full {
  left: 50%;
  transform: translateX(-50%);
}

/* 修改后 */
.desktop-center-full {
  left: 0;
  right: 0;
  margin-left: auto;
  margin-right: auto;
}
```

## Test plan

- [x] 桌面端访问线路列表页
- [x] 点击线路卡片打开抽屉
- [x] 确认抽屉正确居中显示
- [x] 确认抽屉滑动动画正常工作

Closes #42

🤖 Generated with [Claude Code](https://claude.ai/code)