### PR TITLE
feat: add reusable SegmentedControl and clean up carousel UI

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -157,6 +157,7 @@
   },
   "LocaleSwitcher": {
     "switchLanguage": "Switch Language",
+    "languageSelector": "Language Selection",
     "zh": "中文",
     "en": "English"
   },

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -157,6 +157,7 @@
   },
   "LocaleSwitcher": {
     "switchLanguage": "切换语言",
+    "languageSelector": "语言选择",
     "zh": "中文",
     "en": "English"
   },

--- a/src/app/[locale]/crag/[id]/crag-detail-client.tsx
+++ b/src/app/[locale]/crag/[id]/crag-detail-client.tsx
@@ -111,26 +111,19 @@ export default function CragDetailClient({ crag, routes }: CragDetailClientProps
             ))}
           </div>
 
-          {/* 指示器 - 显示当前图片位置 */}
+          {/* 底部圆点指示器 */}
           {images.length > 1 && (
-            <div className="absolute right-4 bottom-4 bg-black/50 px-2 py-1 rounded-full">
-              <span className="text-white text-xs">
-                {currentIndex + 1}/{images.length}
-              </span>
+            <div className="absolute bottom-4 left-1/2 -translate-x-1/2 flex gap-2">
+              {images.map((_, idx) => (
+                <div
+                  key={idx}
+                  className={`w-2 h-2 rounded-full transition-colors ${
+                    idx === currentIndex ? 'bg-white' : 'bg-white/50'
+                  }`}
+                />
+              ))}
             </div>
           )}
-
-          {/* 底部圆点指示器 */}
-          <div className="absolute bottom-4 left-1/2 -translate-x-1/2 flex gap-2">
-            {images.map((_, idx) => (
-              <div
-                key={idx}
-                className={`w-2 h-2 rounded-full transition-colors ${
-                  idx === currentIndex ? 'bg-white' : 'bg-white/50'
-                }`}
-              />
-            ))}
-          </div>
         </div>
       </div>
 

--- a/src/app/[locale]/profile/page.tsx
+++ b/src/app/[locale]/profile/page.tsx
@@ -6,7 +6,7 @@ import { useTranslations } from 'next-intl'
 import { Palette, Heart, Copy, Check, User, Send, Users, Globe } from 'lucide-react'
 import { AppTabbar } from '@/components/app-tabbar'
 import { ThemeSwitcher } from '@/components/theme-switcher'
-import { LocaleSelect } from '@/components/locale-switcher'
+import { LocaleSegmented } from '@/components/locale-switcher'
 import { Drawer } from '@/components/ui/drawer'
 import { ImageViewer } from '@/components/ui/image-viewer'
 // 访问统计缓存 key
@@ -160,7 +160,7 @@ export default function ProfilePage() {
                 {t('language')}
               </span>
             </div>
-            <LocaleSelect />
+            <LocaleSegmented />
           </div>
 
           {/* 关于作者按钮 */}

--- a/src/components/locale-switcher.tsx
+++ b/src/components/locale-switcher.tsx
@@ -4,9 +4,11 @@ import { useLocale, useTranslations } from 'next-intl'
 import { useRouter, usePathname } from '@/i18n/navigation'
 import { Globe } from 'lucide-react'
 import { routing, type Locale } from '@/i18n/routing'
+import { useMemo } from 'react'
+import { SegmentedControl, type SegmentOption } from '@/components/ui/segmented-control'
 
 /**
- * 语言切换器组件
+ * 语言切换器组件 - 简单按钮版本
  *
  * 显示当前语言，点击切换到另一种语言
  * 切换时保持当前页面路径不变
@@ -42,9 +44,54 @@ export function LocaleSwitcher() {
 }
 
 /**
+ * 语言切换器 - 分段控制器版本
+ *
+ * 使用 SegmentedControl 实现语言切换，
+ * 与主题切换器保持一致的视觉风格和交互体验。
+ */
+interface LocaleSegmentedProps {
+  className?: string
+}
+
+export function LocaleSegmented({ className }: LocaleSegmentedProps) {
+  const t = useTranslations('LocaleSwitcher')
+  const locale = useLocale() as Locale
+  const router = useRouter()
+  const pathname = usePathname()
+
+  // 语言选项配置
+  const localeOptions: SegmentOption<Locale>[] = useMemo(() =>
+    routing.locales.map((loc) => ({
+      value: loc,
+      label: t(loc),
+      icon: loc === 'zh' ? (
+        <span className="text-xs font-bold">中</span>
+      ) : (
+        <span className="text-xs font-bold">En</span>
+      ),
+    })),
+    [t]
+  )
+
+  const handleChange = (newLocale: Locale) => {
+    router.replace(pathname, { locale: newLocale })
+  }
+
+  return (
+    <SegmentedControl
+      options={localeOptions}
+      value={locale}
+      onChange={handleChange}
+      ariaLabel={t('languageSelector')}
+      className={className}
+    />
+  )
+}
+
+/**
  * 语言选择器 - 下拉菜单版本
  *
- * 适用于设置页面，显示所有可用语言
+ * 适用于需要紧凑布局的场景
  */
 interface LocaleSelectProps {
   className?: string

--- a/src/components/ui/segmented-control.tsx
+++ b/src/components/ui/segmented-control.tsx
@@ -1,0 +1,199 @@
+'use client'
+
+import { useEffect, useState, useRef, useCallback, type ReactNode } from 'react'
+
+/**
+ * 单个选项的配置
+ */
+export interface SegmentOption<T extends string> {
+  /** 选项值 */
+  value: T
+  /** 显示标签 */
+  label: string
+  /** 可选图标 */
+  icon?: ReactNode
+}
+
+/**
+ * SegmentedControl 组件属性
+ */
+interface SegmentedControlProps<T extends string> {
+  /** 选项列表 */
+  options: SegmentOption<T>[]
+  /** 当前选中值 */
+  value: T
+  /** 值变化回调 */
+  onChange: (value: T) => void
+  /** 无障碍标签 */
+  ariaLabel?: string
+  /** 额外样式类 */
+  className?: string
+  /** 尺寸变体 */
+  size?: 'sm' | 'md'
+}
+
+/**
+ * 分段控制器组件
+ *
+ * 一个带滑动动画的分段选择器，类似 iOS 风格的 Segmented Control。
+ * 支持图标、文字或两者组合。
+ *
+ * @example
+ * ```tsx
+ * <SegmentedControl
+ *   options={[
+ *     { value: 'light', label: '日间', icon: <Sun /> },
+ *     { value: 'dark', label: '暗夜', icon: <Moon /> },
+ *   ]}
+ *   value={theme}
+ *   onChange={setTheme}
+ *   ariaLabel="主题选择"
+ * />
+ * ```
+ */
+export function SegmentedControl<T extends string>({
+  options,
+  value,
+  onChange,
+  ariaLabel,
+  className,
+  size = 'md',
+}: SegmentedControlProps<T>) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [indicatorStyle, setIndicatorStyle] = useState({ left: 0, width: 0 })
+  const [mounted, setMounted] = useState(false)
+
+  // 确保客户端渲染（Next.js SSR hydration 标准模式）
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- SSR hydration 必需
+    setMounted(true)
+  }, [])
+
+  // 计算滑块位置
+  const updateIndicator = useCallback(() => {
+    if (!containerRef.current) return
+
+    const activeIndex = options.findIndex((opt) => opt.value === value)
+    if (activeIndex === -1) return
+
+    const buttons = containerRef.current.querySelectorAll('[role="tab"]')
+    const activeButton = buttons[activeIndex] as HTMLButtonElement
+
+    if (activeButton) {
+      setIndicatorStyle({
+        left: activeButton.offsetLeft,
+        width: activeButton.offsetWidth,
+      })
+    }
+  }, [options, value])
+
+  // 初始化和值变化时更新指示器
+  useEffect(() => {
+    if (mounted) {
+      updateIndicator()
+    }
+  }, [mounted, updateIndicator])
+
+  // 窗口大小变化时重新计算
+  useEffect(() => {
+    if (!mounted) return
+
+    window.addEventListener('resize', updateIndicator)
+    return () => window.removeEventListener('resize', updateIndicator)
+  }, [mounted, updateIndicator])
+
+  // 尺寸配置
+  const sizeConfig = {
+    sm: {
+      padding: 'p-0.5',
+      buttonPadding: 'py-1.5 px-2',
+      iconSize: 'w-3.5 h-3.5',
+      textSize: 'text-xs',
+      gap: 'gap-1',
+    },
+    md: {
+      padding: 'p-1',
+      buttonPadding: 'py-2.5 px-3',
+      iconSize: 'w-4 h-4',
+      textSize: 'text-sm',
+      gap: 'gap-1.5',
+    },
+  }
+
+  const config = sizeConfig[size]
+
+  // SSR 骨架占位
+  if (!mounted) {
+    return (
+      <div
+        className={`h-12 rounded-xl animate-pulse ${className || ''}`}
+        style={{ backgroundColor: 'var(--theme-surface-variant)' }}
+      />
+    )
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className={`relative flex ${config.padding} rounded-xl ${className || ''}`}
+      style={{
+        backgroundColor: 'var(--theme-surface-variant)',
+      }}
+      role="tablist"
+      aria-label={ariaLabel}
+    >
+      {/* 滑动背景指示器 */}
+      <div
+        className="absolute top-1 bottom-1 rounded-lg transition-all duration-300 ease-out"
+        style={{
+          left: indicatorStyle.left,
+          width: indicatorStyle.width,
+          backgroundColor: 'var(--theme-surface)',
+          boxShadow: 'var(--theme-shadow-sm)',
+          // Apple 风格弹性曲线
+          transitionTimingFunction: 'cubic-bezier(0.25, 0.1, 0.25, 1)',
+        }}
+      />
+
+      {/* 选项按钮 */}
+      {options.map((option) => {
+        const isSelected = value === option.value
+
+        return (
+          <button
+            key={option.value}
+            onClick={() => onChange(option.value)}
+            className={`relative z-10 flex-1 flex items-center justify-center ${config.gap} ${config.buttonPadding} rounded-lg transition-colors duration-200`}
+            style={{
+              color: isSelected
+                ? 'var(--theme-primary)'
+                : 'var(--theme-on-surface-variant)',
+            }}
+            role="tab"
+            aria-selected={isSelected}
+            aria-controls={`panel-${option.value}`}
+          >
+            {option.icon && (
+              <span
+                className={`${config.iconSize} transition-transform duration-200 flex items-center justify-center`}
+                style={{
+                  transform: isSelected ? 'scale(1.1)' : 'scale(1)',
+                }}
+              >
+                {option.icon}
+              </span>
+            )}
+            <span
+              className={`${config.textSize} transition-all duration-200`}
+              style={{
+                fontWeight: isSelected ? 600 : 400,
+              }}
+            >
+              {option.label}
+            </span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Create generic `SegmentedControl` component with iOS-style sliding animation
- Refactor theme and locale switchers to use the new component
- Fix duplicate carousel indicator on crag detail page

## Changes

### New Component
- `src/components/ui/segmented-control.tsx` - Reusable iOS-style segmented control with sliding indicator

### Refactored
- `src/components/theme-switcher.tsx` - Now uses SegmentedControl (135 → 66 lines, -51%)
- `src/components/locale-switcher.tsx` - Added `LocaleSegmented` variant
- `src/app/[locale]/profile/page.tsx` - Use LocaleSegmented for language selection

### Fixed
- `src/app/[locale]/crag/[id]/crag-detail-client.tsx` - Remove duplicate carousel indicator (had both counter badge AND dots)

### i18n
- Added `languageSelector` key to both `messages/en.json` and `messages/zh.json`

## Test plan
- [x] All 304 Vitest tests pass
- [x] All 5 Playwright component tests pass
- [x] ESLint passes (0 errors)
- [ ] Manual test: Theme switcher works correctly
- [ ] Manual test: Language switcher works correctly
- [ ] Manual test: Crag detail page shows only dot indicators

Closes #51

🤖 Generated with [Claude Code](https://claude.ai/code)