### PR TITLE
feat(i18n): add smart locale preference with IP detection and caching

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -6,6 +6,7 @@ import { routing } from '@/i18n/routing'
 import { ThemeProvider } from '@/components/theme-provider'
 import OfflineIndicator from '@/components/offline-indicator'
 import SWUpdatePrompt from '@/components/sw-update-prompt'
+import { LocaleDetector } from '@/components/locale-detector'
 
 type Props = {
   children: React.ReactNode
@@ -91,6 +92,7 @@ export default async function LocaleLayout({ children, params }: Props) {
               backgroundColor: 'var(--theme-surface)',
             }}
           >
+            <LocaleDetector />
             <OfflineIndicator />
             {children}
             <SWUpdatePrompt />

--- a/src/components/locale-detector.tsx
+++ b/src/components/locale-detector.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { useLocalePreference } from '@/hooks/use-locale-preference'
+
+/**
+ * 语言检测组件
+ *
+ * 这是一个无 UI 的组件，放在布局中触发首次语言检测逻辑：
+ * 1. 检查 localStorage 是否有缓存的语言偏好
+ * 2. 如果没有，通过 IP 定位判断用户所在地区
+ * 3. 中国用户默认中文，其他地区默认英文
+ *
+ * 只在首次访问时执行检测，后续使用缓存。
+ */
+export function LocaleDetector() {
+  // 使用 hook 触发检测逻辑
+  // hook 内部会自动处理首次检测和重定向
+  useLocalePreference()
+
+  // 不渲染任何内容
+  return null
+}

--- a/src/components/locale-switcher.tsx
+++ b/src/components/locale-switcher.tsx
@@ -1,28 +1,26 @@
 'use client'
 
-import { useLocale, useTranslations } from 'next-intl'
-import { useRouter, usePathname } from '@/i18n/navigation'
+import { useTranslations } from 'next-intl'
 import { Globe } from 'lucide-react'
 import { routing, type Locale } from '@/i18n/routing'
 import { useMemo } from 'react'
 import { SegmentedControl, type SegmentOption } from '@/components/ui/segmented-control'
+import { useLocalePreference } from '@/hooks/use-locale-preference'
 
 /**
  * 语言切换器组件 - 简单按钮版本
  *
  * 显示当前语言，点击切换到另一种语言
- * 切换时保持当前页面路径不变
+ * 切换时保持当前页面路径不变，并更新 localStorage 缓存
  */
 export function LocaleSwitcher() {
   const t = useTranslations('LocaleSwitcher')
-  const locale = useLocale() as Locale
-  const router = useRouter()
-  const pathname = usePathname()
+  const { locale, switchLocale } = useLocalePreference()
 
   const handleSwitch = () => {
     // 切换到另一种语言
     const nextLocale = locale === 'zh' ? 'en' : 'zh'
-    router.replace(pathname, { locale: nextLocale })
+    switchLocale(nextLocale)
   }
 
   return (
@@ -48,6 +46,7 @@ export function LocaleSwitcher() {
  *
  * 使用 SegmentedControl 实现语言切换，
  * 与主题切换器保持一致的视觉风格和交互体验。
+ * 切换时自动更新 localStorage 缓存。
  */
 interface LocaleSegmentedProps {
   className?: string
@@ -55,9 +54,7 @@ interface LocaleSegmentedProps {
 
 export function LocaleSegmented({ className }: LocaleSegmentedProps) {
   const t = useTranslations('LocaleSwitcher')
-  const locale = useLocale() as Locale
-  const router = useRouter()
-  const pathname = usePathname()
+  const { locale, switchLocale } = useLocalePreference()
 
   // 语言选项配置
   const localeOptions: SegmentOption<Locale>[] = useMemo(() =>
@@ -73,15 +70,11 @@ export function LocaleSegmented({ className }: LocaleSegmentedProps) {
     [t]
   )
 
-  const handleChange = (newLocale: Locale) => {
-    router.replace(pathname, { locale: newLocale })
-  }
-
   return (
     <SegmentedControl
       options={localeOptions}
       value={locale}
-      onChange={handleChange}
+      onChange={switchLocale}
       ariaLabel={t('languageSelector')}
       className={className}
     />
@@ -92,6 +85,7 @@ export function LocaleSegmented({ className }: LocaleSegmentedProps) {
  * 语言选择器 - 下拉菜单版本
  *
  * 适用于需要紧凑布局的场景
+ * 切换时自动更新 localStorage 缓存。
  */
 interface LocaleSelectProps {
   className?: string
@@ -99,13 +93,11 @@ interface LocaleSelectProps {
 
 export function LocaleSelect({ className }: LocaleSelectProps) {
   const t = useTranslations('LocaleSwitcher')
-  const locale = useLocale() as Locale
-  const router = useRouter()
-  const pathname = usePathname()
+  const { locale, switchLocale } = useLocalePreference()
 
   const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const newLocale = e.target.value as Locale
-    router.replace(pathname, { locale: newLocale })
+    switchLocale(newLocale)
   }
 
   return (

--- a/src/hooks/use-locale-preference.ts
+++ b/src/hooks/use-locale-preference.ts
@@ -1,0 +1,152 @@
+'use client'
+
+import { useEffect, useCallback, useRef } from 'react'
+import { useRouter, usePathname } from '@/i18n/navigation'
+import { useLocale } from 'next-intl'
+import type { Locale } from '@/i18n/routing'
+
+/**
+ * 语言偏好缓存 key
+ * 存储在 localStorage 中，永久保存
+ */
+const LOCALE_CACHE_KEY = 'preferred-locale'
+
+/**
+ * 标记是否已完成首次语言检测
+ * 存储在 sessionStorage 中，避免每次导航都触发检测
+ */
+const LOCALE_DETECTED_KEY = 'locale-detected'
+
+/**
+ * 获取缓存的语言偏好
+ */
+function getCachedLocale(): Locale | null {
+  if (typeof window === 'undefined') return null
+  const cached = localStorage.getItem(LOCALE_CACHE_KEY)
+  if (cached === 'zh' || cached === 'en') {
+    return cached
+  }
+  return null
+}
+
+/**
+ * 设置语言偏好缓存
+ */
+function setCachedLocale(locale: Locale): void {
+  if (typeof window === 'undefined') return
+  localStorage.setItem(LOCALE_CACHE_KEY, locale)
+}
+
+/**
+ * 检查是否已在本次会话中完成检测
+ */
+function isDetected(): boolean {
+  if (typeof window === 'undefined') return false
+  return sessionStorage.getItem(LOCALE_DETECTED_KEY) === 'true'
+}
+
+/**
+ * 标记本次会话已完成检测
+ */
+function markDetected(): void {
+  if (typeof window === 'undefined') return
+  sessionStorage.setItem(LOCALE_DETECTED_KEY, 'true')
+}
+
+/**
+ * 根据 IP 检测推荐语言
+ * 中国 IP 返回 'zh'，其他返回 'en'
+ */
+async function detectLocaleByIP(): Promise<Locale> {
+  try {
+    const response = await fetch('/api/geo')
+    if (!response.ok) {
+      return 'en' // 检测失败默认英文（国际用户）
+    }
+
+    const data = await response.json()
+    // 如果有 province 字段说明是中国 IP（高德只返回中国地区数据）
+    // 或检查 detected 为 true 也说明是中国
+    const isChina = !!(data.province || data.detected)
+    return isChina ? 'zh' : 'en'
+  } catch {
+    return 'en' // 网络错误默认英文
+  }
+}
+
+/**
+ * 语言偏好管理 Hook
+ *
+ * 实现逻辑:
+ * 1. 首次访问：检查 localStorage 缓存
+ *    - 有缓存：使用缓存的语言
+ *    - 无缓存：调用 /api/geo 检测 IP 位置
+ *      - 中国 IP：使用中文
+ *      - 其他地区：使用英文
+ * 2. 用户切换语言：更新 localStorage 缓存
+ * 3. 后续访问：直接使用缓存
+ */
+export function useLocalePreference() {
+  const currentLocale = useLocale() as Locale
+  const router = useRouter()
+  const pathname = usePathname()
+  const detectingRef = useRef(false)
+
+  /**
+   * 切换语言并更新缓存
+   */
+  const switchLocale = useCallback((newLocale: Locale) => {
+    setCachedLocale(newLocale)
+    router.replace(pathname, { locale: newLocale })
+  }, [router, pathname])
+
+  /**
+   * 首次加载时检测语言偏好
+   */
+  useEffect(() => {
+    // 已经在本次会话中检测过，跳过
+    if (isDetected()) {
+      return
+    }
+
+    // 检查缓存
+    const cachedLocale = getCachedLocale()
+
+    if (cachedLocale) {
+      // 有缓存，使用缓存的语言
+      markDetected()
+      if (cachedLocale !== currentLocale) {
+        router.replace(pathname, { locale: cachedLocale })
+      }
+      return
+    }
+
+    // 防止重复检测
+    if (detectingRef.current) {
+      return
+    }
+    detectingRef.current = true
+
+    // 无缓存，需要通过 IP 检测
+    detectLocaleByIP().then((detectedLocale) => {
+      markDetected()
+      setCachedLocale(detectedLocale)
+      detectingRef.current = false
+
+      if (detectedLocale !== currentLocale) {
+        router.replace(pathname, { locale: detectedLocale })
+      }
+    })
+  }, [currentLocale, router, pathname])
+
+  return {
+    /** 当前语言 */
+    locale: currentLocale,
+    /** 切换语言（会更新缓存） */
+    switchLocale,
+    /** 获取缓存的语言偏好 */
+    getCachedLocale,
+    /** 手动设置缓存（不会触发导航） */
+    setCachedLocale,
+  }
+}


### PR DESCRIPTION
## Summary
- Add intelligent language preference system with automatic IP-based detection
- Cache user's language choice permanently in localStorage
- Chinese IP users default to Chinese, others default to English
- All locale switcher variants now persist preference on change

## Changes
- **New**: `src/hooks/use-locale-preference.ts` - Language preference management hook
- **New**: `src/components/locale-detector.tsx` - Silent detection component for layout
- **Modified**: `src/components/locale-switcher.tsx` - Use new hook for all variants
- **Modified**: `src/app/[locale]/layout.tsx` - Add LocaleDetector component

## How It Works
```
First Visit:
1. Check localStorage for cached preference
2. If cached → use cached locale
3. If not cached → call /api/geo to detect IP location
4. China IP → 'zh', Others → 'en'
5. Save to localStorage (permanent)

Subsequent Visits:
1. Check localStorage → use cached locale
2. Skip IP detection

Language Switch:
1. User selects new language
2. Update localStorage cache
3. Navigate to new locale
```

## Storage Keys
| Key | Storage | Purpose |
|-----|---------|---------|
| `preferred-locale` | localStorage | Permanent language preference |
| `locale-detected` | sessionStorage | Prevent repeated detection in session |

Closes #55

## Test Plan
- [ ] First visit with no cache triggers IP detection
- [ ] Chinese IP users see Chinese interface
- [ ] Non-Chinese IP users see English interface
- [ ] Language switch updates localStorage
- [ ] Subsequent visits use cached preference
- [ ] All locale switcher variants work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)