### PR TITLE
feat(editor): add faceId management for shared rock face images

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,9 @@ src/
 │   ├── app-tabbar.tsx     # 底部导航栏 (毛玻璃效果)
 │   ├── filter-chip.tsx    # 筛选芯片组件 (单选/多选)
 │   ├── filter-drawer.tsx  # 筛选面板抽屉
-│   ├── route-detail-drawer.tsx  # 线路详情抽屉
+│   ├── route-detail-drawer.tsx  # 线路详情抽屉 (支持多线路切换)
+│   ├── topo-line-overlay.tsx    # Topo 线路 SVG 叠加层 (单线路)
+│   ├── multi-topo-line-overlay.tsx # Topo 多线路叠加层 (岩面共享模式)
 │   ├── beta-list-drawer.tsx     # Beta 视频列表抽屉
 │   ├── floating-search.tsx # 浮动搜索按钮
 │   ├── search-overlay.tsx # 搜索覆盖层
@@ -200,11 +202,13 @@ interface Route {
   grade: string           // V0-V13 或 "？" (Hueco V-Scale 难度等级)
   cragId: string          // 关联岩场
   area: string            // 区域
+  faceId?: string         // 岩面 ID，同一 faceId 的线路共享图片
   setter?: string
   FA?: string             // 首攀者
   description?: string
   image?: string
   betaLinks?: BetaLink[]  // Beta 视频链接
+  topoLine?: TopoPoint[]  // Topo 线路标注 (归一化坐标)
 }
 
 // Beta 视频链接（目前仅支持小红书）

--- a/src/app/[locale]/route/route-client.tsx
+++ b/src/app/[locale]/route/route-client.tsx
@@ -117,6 +117,31 @@ export default function RouteListClient({ routes, crags }: RouteListClientProps)
     return crags.find((c) => c.id === selectedRoute.cragId) || null
   }, [selectedRoute, crags])
 
+  // 获取同岩面的线路（用于多线路叠加显示）
+  const siblingRoutes = useMemo(() => {
+    if (!selectedRoute) return []
+
+    // 优先使用 faceId 匹配
+    if (selectedRoute.faceId) {
+      return routes.filter(r =>
+        r.faceId === selectedRoute.faceId &&
+        r.topoLine && r.topoLine.length >= 2
+      )
+    }
+
+    // 回退到 area + cragId 匹配（向后兼容）
+    return routes.filter(r =>
+      r.cragId === selectedRoute.cragId &&
+      r.area === selectedRoute.area &&
+      r.topoLine && r.topoLine.length >= 2
+    )
+  }, [routes, selectedRoute])
+
+  // 处理线路切换
+  const handleRouteChange = useCallback((route: Route) => {
+    setSelectedRoute(route)
+  }, [])
+
   // 筛选逻辑
   const filteredRoutes = useMemo(() => {
     let result = routes
@@ -314,7 +339,9 @@ export default function RouteListClient({ routes, crags }: RouteListClientProps)
         isOpen={isDetailDrawerOpen}
         onClose={() => setIsDetailDrawerOpen(false)}
         route={selectedRoute}
+        siblingRoutes={siblingRoutes}
         crag={selectedCragData}
+        onRouteChange={handleRouteChange}
       />
 
       {/* 底部导航栏 */}

--- a/src/app/api/routes/[id]/route.ts
+++ b/src/app/api/routes/[id]/route.ts
@@ -133,6 +133,20 @@ export async function PATCH(
       updates.image = body.image?.trim() || undefined
     }
 
+    // 验证 faceId
+    if (body.faceId !== undefined) {
+      if (body.faceId === null) {
+        updates.faceId = undefined
+      } else if (typeof body.faceId === 'string' && /^[a-z0-9-]+$/.test(body.faceId)) {
+        updates.faceId = body.faceId
+      } else {
+        return NextResponse.json(
+          { success: false, error: 'faceId 格式无效，仅允许小写字母、数字和连字符' },
+          { status: 400 }
+        )
+      }
+    }
+
     // 验证 topoLine
     if (body.topoLine !== undefined) {
       if (body.topoLine === null) {

--- a/src/components/multi-topo-line-overlay.tsx
+++ b/src/components/multi-topo-line-overlay.tsx
@@ -1,0 +1,268 @@
+'use client'
+
+import { useRef, useCallback, useEffect, useMemo, useState, forwardRef, useImperativeHandle } from 'react'
+import type { TopoPoint } from '@/types'
+import { bezierCurve, scalePoints } from '@/lib/topo-utils'
+import { getGradeColor } from '@/lib/tokens'
+import {
+  TOPO_VIEW_WIDTH,
+  TOPO_VIEW_HEIGHT,
+  TOPO_LINE_CONFIG,
+  TOPO_MARKER_CONFIG,
+  TOPO_ANIMATION_CONFIG,
+  TOPO_MULTI_LINE_CONFIG,
+} from '@/lib/topo-constants'
+
+/**
+ * 简化的线路数据（用于多线路叠加显示）
+ */
+export interface MultiTopoRoute {
+  id: number
+  name: string
+  grade: string
+  topoLine: TopoPoint[]
+}
+
+export interface MultiTopoLineOverlayProps {
+  /** 同一岩面的所有线路 */
+  routes: MultiTopoRoute[]
+  /** 当前选中的线路 ID */
+  selectedRouteId: number
+  /** 线路切换回调 */
+  onRouteSelect: (routeId: number) => void
+  /** 图片填充模式 */
+  objectFit?: 'cover' | 'contain'
+}
+
+export interface MultiTopoLineOverlayRef {
+  /** 重播选中线路的动画 */
+  replay: () => void
+}
+
+/**
+ * 多线路 Topo SVG 叠加层组件
+ *
+ * 用于在岩面图片上叠加显示多条攀岩线路，支持：
+ * - 选中线路高亮显示 + 画线动画
+ * - 未选中线路灰色弱化显示
+ * - 点击未选中线路起点切换选中
+ * - 丝滑的切换过渡动画
+ */
+export const MultiTopoLineOverlay = forwardRef<MultiTopoLineOverlayRef, MultiTopoLineOverlayProps>(
+  function MultiTopoLineOverlay(
+    {
+      routes,
+      selectedRouteId,
+      onRouteSelect,
+      objectFit = 'cover',
+    },
+    ref
+  ) {
+    const selectedPathRef = useRef<SVGPathElement>(null)
+    const [isAnimating, setIsAnimating] = useState(false)
+
+    // 找到当前选中的线路
+    const selectedRoute = useMemo(
+      () => routes.find(r => r.id === selectedRouteId),
+      [routes, selectedRouteId]
+    )
+
+    // 未选中的线路
+    const inactiveRoutes = useMemo(
+      () => routes.filter(r => r.id !== selectedRouteId),
+      [routes, selectedRouteId]
+    )
+
+    // 预计算所有线路的路径数据
+    const routePathData = useMemo(() => {
+      const map = new Map<number, { path: string; start: TopoPoint; end: TopoPoint }>()
+
+      routes.forEach(route => {
+        if (route.topoLine.length < 2) return
+
+        const scaledPoints = scalePoints(route.topoLine, TOPO_VIEW_WIDTH, TOPO_VIEW_HEIGHT)
+        map.set(route.id, {
+          path: bezierCurve(scaledPoints),
+          start: scaledPoints[0],
+          end: scaledPoints[scaledPoints.length - 1],
+        })
+      })
+
+      return map
+    }, [routes])
+
+    // 画线动画函数
+    const animate = useCallback(() => {
+      const path = selectedPathRef.current
+      if (!path) return
+
+      setIsAnimating(true)
+
+      const length = path.getTotalLength()
+
+      // 重置：隐藏线条
+      path.style.transition = 'none'
+      path.style.strokeDasharray = `${length} ${length}`
+      path.style.strokeDashoffset = `${length}`
+
+      // 强制浏览器重排
+      path.getBoundingClientRect()
+
+      // 动画：显示线条
+      path.style.transition = `stroke-dashoffset ${TOPO_ANIMATION_CONFIG.duration} ${TOPO_ANIMATION_CONFIG.easing}`
+      path.style.strokeDashoffset = '0'
+
+      // 动画完成回调
+      const handleTransitionEnd = () => {
+        setIsAnimating(false)
+        path.removeEventListener('transitionend', handleTransitionEnd)
+      }
+      path.addEventListener('transitionend', handleTransitionEnd)
+    }, [])
+
+    // 暴露 replay 方法给父组件
+    useImperativeHandle(ref, () => ({
+      replay: animate,
+    }), [animate])
+
+    // 选中线路变化时播放动画
+    useEffect(() => {
+      if (selectedRoute) {
+        const timer = setTimeout(() => {
+          animate()
+        }, TOPO_MULTI_LINE_CONFIG.drawAnimationDelay)
+        return () => clearTimeout(timer)
+      }
+    }, [selectedRouteId, animate, selectedRoute])
+
+    // 处理线路切换
+    const handleRouteClick = useCallback((routeId: number) => {
+      if (routeId !== selectedRouteId && !isAnimating) {
+        onRouteSelect(routeId)
+      }
+    }, [selectedRouteId, isAnimating, onRouteSelect])
+
+    // 没有有效线路时不渲染
+    if (routes.length === 0 || !selectedRoute) return null
+
+    const selectedData = routePathData.get(selectedRouteId)
+    if (!selectedData) return null
+
+    const selectedColor = getGradeColor(selectedRoute.grade)
+
+    // SVG preserveAspectRatio 映射
+    const preserveAspectRatio = objectFit === 'contain' ? 'xMidYMid meet' : 'xMidYMid slice'
+
+    return (
+      <svg
+        className="absolute inset-0 w-full h-full pointer-events-none"
+        viewBox={`0 0 ${TOPO_VIEW_WIDTH} ${TOPO_VIEW_HEIGHT}`}
+        preserveAspectRatio={preserveAspectRatio}
+      >
+        {/* 未选中线路 (先渲染，在底层) */}
+        {inactiveRoutes.map(route => {
+          const data = routePathData.get(route.id)
+          if (!data) return null
+
+          return (
+            <g
+              key={route.id}
+              opacity={TOPO_MULTI_LINE_CONFIG.inactiveOpacity}
+              style={{
+                transition: `opacity ${TOPO_MULTI_LINE_CONFIG.fadeOutDuration}ms ease-out`,
+              }}
+            >
+              {/* 外层白色描边 */}
+              <path
+                d={data.path}
+                stroke="white"
+                strokeWidth={TOPO_MULTI_LINE_CONFIG.inactiveOutlineWidth}
+                strokeLinecap={TOPO_LINE_CONFIG.strokeLinecap}
+                strokeLinejoin={TOPO_LINE_CONFIG.strokeLinejoin}
+                fill="none"
+                opacity={TOPO_LINE_CONFIG.outlineOpacity}
+              />
+              {/* 主线条 */}
+              <path
+                d={data.path}
+                stroke={TOPO_MULTI_LINE_CONFIG.inactiveColor}
+                strokeWidth={TOPO_MULTI_LINE_CONFIG.inactiveStrokeWidth}
+                strokeLinecap={TOPO_LINE_CONFIG.strokeLinecap}
+                strokeLinejoin={TOPO_LINE_CONFIG.strokeLinejoin}
+                fill="none"
+              />
+              {/* 起点标记 - 可点击切换 */}
+              <circle
+                cx={data.start.x}
+                cy={data.start.y}
+                r={TOPO_MULTI_LINE_CONFIG.inactiveMarkerRadius}
+                fill={TOPO_MULTI_LINE_CONFIG.inactiveColor}
+                stroke="white"
+                strokeWidth={1.5}
+                style={{ cursor: 'pointer', pointerEvents: 'auto' }}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  handleRouteClick(route.id)
+                }}
+              />
+            </g>
+          )
+        })}
+
+        {/* 选中线路 (后渲染，在顶层) */}
+        <g
+          style={{
+            transition: `opacity ${TOPO_MULTI_LINE_CONFIG.fadeInDuration}ms ease-in`,
+          }}
+        >
+          {/* 外层白色描边 */}
+          <path
+            d={selectedData.path}
+            stroke="white"
+            strokeWidth={TOPO_LINE_CONFIG.outlineWidth}
+            strokeLinecap={TOPO_LINE_CONFIG.strokeLinecap}
+            strokeLinejoin={TOPO_LINE_CONFIG.strokeLinejoin}
+            fill="none"
+            opacity={TOPO_LINE_CONFIG.outlineOpacity}
+          />
+
+          {/* 主线条 (带画线动画) */}
+          <path
+            ref={selectedPathRef}
+            d={selectedData.path}
+            stroke={selectedColor}
+            strokeWidth={TOPO_LINE_CONFIG.strokeWidth}
+            strokeLinecap={TOPO_LINE_CONFIG.strokeLinecap}
+            strokeLinejoin={TOPO_LINE_CONFIG.strokeLinejoin}
+            fill="none"
+          />
+
+          {/* 起点 - 可点击触发重播动画 */}
+          <circle
+            cx={selectedData.start.x}
+            cy={selectedData.start.y}
+            r={TOPO_MARKER_CONFIG.startRadius}
+            fill={selectedColor}
+            stroke="white"
+            strokeWidth={TOPO_MARKER_CONFIG.strokeWidth}
+            style={{ cursor: 'pointer', pointerEvents: 'auto' }}
+            onClick={(e) => {
+              e.stopPropagation()
+              animate()
+            }}
+          />
+
+          {/* 终点 */}
+          <circle
+            cx={selectedData.end.x}
+            cy={selectedData.end.y}
+            r={TOPO_MARKER_CONFIG.endRadius}
+            fill="white"
+            stroke={selectedColor}
+            strokeWidth={TOPO_MARKER_CONFIG.endStrokeWidth}
+          />
+        </g>
+      </svg>
+    )
+  }
+)

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,3 +1,5 @@
+import type { Route } from '@/types'
+
 /**
  * Cloudflare R2 图片存储配置
  */
@@ -37,4 +39,36 @@ export function getRouteTopoUrl(
  */
 export function getCragCoverUrl(cragId: string, index: number): string {
   return `${IMAGE_BASE_URL}/CragSurface/${cragId}/${index}.jpg?v=${IMAGE_VERSION}`
+}
+
+/**
+ * 生成岩面 Topo 图片 URL（新策略）
+ * 同一 faceId 的线路共享同一张图片
+ *
+ * @param cragId - 岩场 ID
+ * @param faceId - 岩面 ID
+ * @param timestamp - 可选时间戳，用于刚上传后强制刷新缓存
+ */
+export function getFaceTopoUrl(
+  cragId: string,
+  faceId: string,
+  timestamp?: number
+): string {
+  const version = timestamp ? `t=${timestamp}` : `v=${IMAGE_VERSION}`
+  return `${IMAGE_BASE_URL}/${cragId}/faces/${encodeURIComponent(faceId)}.jpg?${version}`
+}
+
+/**
+ * 智能获取 Topo 图片 URL（兼容新旧数据）
+ * - 有 faceId: 使用岩面图片路径
+ * - 无 faceId: 回退到线路名称图片路径
+ *
+ * @param route - 线路数据
+ * @param timestamp - 可选时间戳
+ */
+export function getTopoImageUrl(route: Route, timestamp?: number): string {
+  if (route.faceId) {
+    return getFaceTopoUrl(route.cragId, route.faceId, timestamp)
+  }
+  return getRouteTopoUrl(route.cragId, route.name, timestamp)
 }

--- a/src/lib/topo-constants.ts
+++ b/src/lib/topo-constants.ts
@@ -44,3 +44,27 @@ export const TOPO_ANIMATION_CONFIG = {
   /** 全屏模式自动播放延迟 (ms) */
   autoPlayDelayFullscreen: 500,
 } as const
+
+// 多线路叠加配置（岩面共享模式）
+export const TOPO_MULTI_LINE_CONFIG = {
+  /** 未选中线路透明度 */
+  inactiveOpacity: 0.4,
+  /** 未选中线路颜色 */
+  inactiveColor: '#888888',
+  /** 未选中线路宽度 */
+  inactiveStrokeWidth: 3,
+  /** 未选中线路外层描边宽度 */
+  inactiveOutlineWidth: 5,
+  /** 未选中起点标记半径 */
+  inactiveMarkerRadius: 6,
+
+  /** 选中线路起点标记半径 (略大于普通起点) */
+  selectedMarkerRadius: 10,
+
+  /** 切换动画：淡出时间 (ms) */
+  fadeOutDuration: 50,
+  /** 切换动画：淡入时间 (ms) */
+  fadeInDuration: 50,
+  /** 切换动画：画线动画延迟 (ms) */
+  drawAnimationDelay: 100,
+} as const

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,6 +17,7 @@ export interface Route {
   grade: string // V0-V13 或 "？"
   cragId: string
   area: string
+  faceId?: string // 岩面 ID，同一 faceId 的线路共享图片
   setter?: string
   FA?: string
   description?: string


### PR DESCRIPTION
## Summary

- 新增 `faceId` 字段支持多条线路共享同一张岩面照片
- PATCH `/api/routes/[id]` 和 POST `/api/upload` 支持 faceId 参数
- 编辑器新增「岩面分配」区域：无岩面 / 选择已有 / 新建岩面
- 前端消费侧：智能图片路由 `getTopoImageUrl`、`MultiTopoLineOverlay` 多线路叠加

## Test plan

- [x] `npx tsc --noEmit` 类型检查通过
- [x] `npm run test:run` — 598 测试全部通过
- [ ] 编辑器页面手动验证：新建岩面 → 上传图片 → 保存
- [ ] 第二条线路选择已有岩面 → 图片自动加载
- [ ] 前台线路详情页验证多线路叠加显示

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)