### PR TITLE
feat(editor): support Chinese characters in faceId

### DIFF
--- a/src/app/[locale]/editor/faces/page.tsx
+++ b/src/app/[locale]/editor/faces/page.tsx
@@ -326,7 +326,7 @@ export default function FaceManagementPage() {
   )
 
   // ============ 右栏：详情/新建 ============
-  const canCreate = isCreating && newFaceId && /^[a-z0-9-]+$/.test(newFaceId) && uploadedFile
+  const canCreate = isCreating && newFaceId && /^[\u4e00-\u9fffa-z0-9-]+$/.test(newFaceId) && uploadedFile
 
   const rightPanel = (
     <div className="h-full overflow-y-auto">
@@ -375,15 +375,15 @@ export default function FaceManagementPage() {
               </label>
               <input
                 type="text"
-                placeholder="如 main-wall-1（小写字母、数字、连字符）"
+                placeholder="如 主墙-1 或 main-wall-1"
                 value={newFaceId}
-                onChange={(e) => setNewFaceId(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ''))}
+                onChange={(e) => setNewFaceId(e.target.value.toLowerCase().replace(/[^\u4e00-\u9fffa-z0-9-]/g, ''))}
                 className="w-full px-3 py-2.5 rounded-xl text-sm outline-none transition-all duration-200 focus:ring-2 focus:ring-[var(--theme-primary)]"
                 style={{ backgroundColor: 'var(--theme-surface)', color: 'var(--theme-on-surface)' }}
               />
-              {newFaceId && !/^[a-z0-9-]+$/.test(newFaceId) && (
+              {newFaceId && !/^[\u4e00-\u9fffa-z0-9-]+$/.test(newFaceId) && (
                 <p className="text-xs mt-1.5" style={{ color: 'var(--theme-error)' }}>
-                  只允许小写字母、数字和连字符
+                  只允许中文、小写字母、数字和连字符
                 </p>
               )}
               {newFaceId && faceGroups.some(f => f.faceId === newFaceId) && (

--- a/src/app/api/routes/[id]/route.ts
+++ b/src/app/api/routes/[id]/route.ts
@@ -137,11 +137,11 @@ export async function PATCH(
     if (body.faceId !== undefined) {
       if (body.faceId === null) {
         updates.faceId = undefined
-      } else if (typeof body.faceId === 'string' && /^[a-z0-9-]+$/.test(body.faceId)) {
+      } else if (typeof body.faceId === 'string' && /^[\u4e00-\u9fffa-z0-9-]+$/.test(body.faceId)) {
         updates.faceId = body.faceId
       } else {
         return NextResponse.json(
-          { success: false, error: 'faceId 格式无效，仅允许小写字母、数字和连字符' },
+          { success: false, error: 'faceId 格式无效，仅允许中文、小写字母、数字和连字符' },
           { status: 400 }
         )
       }


### PR DESCRIPTION
## Summary

- 允许 faceId 使用中文字符（如 `主墙-1`、`圆通寺大面`）
- 更新前端输入过滤和验证正则：`/^[\u4e00-\u9fffa-z0-9-]+$/`
- 更新后端 API 验证正则保持一致

## Test plan

- [ ] 输入中文 faceId（如「主墙-1」）可正常创建
- [ ] 纯英文 faceId 仍然正常
- [ ] 特殊字符（空格、斜杠等）仍被过滤
- [ ] API 保存含中文 faceId 的线路成功

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)