### PR TITLE
fix(editor): use selected faceId for topo image loading

### DIFF
--- a/src/app/[locale]/editor/routes/page.tsx
+++ b/src/app/[locale]/editor/routes/page.tsx
@@ -184,9 +184,10 @@ export default function RouteAnnotationPage() {
       return
     }
 
-    // 图片来源：face 图片
-    if (selectedRoute.faceId) {
-      const url = getFaceTopoUrl(selectedRoute.cragId, selectedRoute.faceId)
+    // 图片来源：优先使用当前选中的 faceId，其次用线路自身的 faceId
+    const faceId = selectedFaceId || selectedRoute.faceId
+    if (faceId) {
+      const url = getFaceTopoUrl(selectedRoute.cragId, faceId)
       setImageUrl(url)
       setIsImageLoading(true)
       setImageLoadError(false)


### PR DESCRIPTION
## Summary

- 修复线路标注页面不显示已上传岩面图片的问题
- 图片加载优先使用左栏选中的 `selectedFaceId`，回退到线路自身的 `faceId`

## Test plan

- [ ] 选择岩面 → 选择线路 → 岩面图片正常显示
- [ ] 线路自身有 faceId 时也能正常显示

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)