### PR TITLE
feat(editor): faces mobile adapt, R2 restructure & fix loading bug

### DIFF
--- a/src/app/[locale]/editor/routes/page.tsx
+++ b/src/app/[locale]/editor/routes/page.tsx
@@ -233,8 +233,12 @@ export default function RouteAnnotationPage() {
 
     if (autoFaceId && selectedRoute.area) {
       const url = getFaceTopoUrl(selectedRoute.cragId, selectedRoute.area, autoFaceId)
-      setImageUrl(url)
-      setIsImageLoading(true)
+      // 仅当 URL 变化时才触发 loading，避免同岩面切换线路时 onLoad 不触发导致永久 loading
+      setImageUrl(prev => {
+        if (prev === url) return prev
+        setIsImageLoading(true)
+        return url
+      })
       setImageLoadError(false)
     } else {
       setImageUrl(null)
@@ -583,6 +587,7 @@ export default function RouteAnnotationPage() {
 
                   {/* eslint-disable-next-line @next/next/no-img-element */}
                   <img
+                    key={imageUrl}
                     src={imageUrl}
                     alt="岩面照片"
                     className="w-full aspect-[4/3] object-cover"


### PR DESCRIPTION
## Summary
Closes #95

- **移动端适配**: 岩面管理页新增列表/详情切换模式，适配小屏设备
- **R2 存储重构**: 岩面图片路径从扁平结构迁移为 `{cragId}/{area}/{faceId}.jpg` 分层
- **岩面删除功能**: 支持删除 R2 图片并自动清除关联线路的 faceId
- **修复加载卡死 bug**: 切换共享同一岩面的线路时，不再永久显示"加载云端图片"

## Key fix
当两条线路共享同一个岩面时，`imageUrl` 不变但 `isImageLoading` 被无条件设为 `true`，浏览器缓存命中不触发 `onLoad`，导致 loading 永远无法解除。修复：使用函数式 `setState` 仅在 URL 实际变化时触发 loading。

## Test plan
- [x] 切换共享同一岩面的线路（艳阳天↔黑爆），图片即时显示无卡顿
- [ ] 移动端访问岩面管理页，验证列表/详情切换正常
- [ ] 上传/删除岩面功能正常
- [ ] 桌面端功能无回退

🤖 Generated with [Claude Code](https://claude.com/claude-code)