### PR TITLE
feat(profile): move editor entry to password-protected settings page

### DIFF
--- a/PROJECT_INDEX.md
+++ b/PROJECT_INDEX.md
@@ -1,6 +1,6 @@
 # Project Index: 罗源野抱 TOPO PWA
 
-Generated: 2026-01-30
+Generated: 2026-01-30 (updated)
 
 ## 📁 Project Structure
 
@@ -51,6 +51,7 @@ src/
 │   │   └── segmented-control.tsx    # Tab-like segmented control
 │   ├── editor/                       # Editor-specific components
 │   │   ├── fullscreen-topo-editor.tsx # SVG topo line editor
+│   │   ├── crag-selector.tsx        # Editor crag selector
 │   │   ├── progress-ring.tsx        # Circular progress indicator
 │   │   └── route-card.tsx           # Editor route card
 │   ├── crag-card.tsx                # Crag list card
@@ -136,13 +137,14 @@ scripts/
 ├── check-routes.ts                  # Route data validation
 ├── migrate-add-cityid.ts           # Add cityId migration
 ├── migrate-r2-face-keys.ts         # R2 face key migration
+├── migrate-r2-face-to-area.ts      # R2 face→area hierarchy migration
 └── init-visits.ts                   # Initialize visit counters
 ```
 
 ## 🚀 Entry Points
 
 - **App**: `src/app/[locale]/page.tsx` — Homepage (crag list, SSR + ISR)
-- **API**: `src/app/api/` — 11 API routes
+- **API**: `src/app/api/` — 12 API routes
 - **SW**: `src/app/sw.ts` — Serwist service worker
 - **Middleware**: `src/middleware.ts` — i18n locale detection
 - **DB seed**: `scripts/seed.ts` — Database migration

--- a/messages/en.json
+++ b/messages/en.json
@@ -315,7 +315,13 @@
     "feedbackThanks": "Thanks for your feedback 💚",
     "donate": "Buy me a coffee ☕️",
     "avatarAlt": "Author avatar",
-    "donateAlt": "Donate QR code"
+    "donateAlt": "Donate QR code",
+    "editorEntry": "Topo Editor",
+    "editorEntryHint": "Password required",
+    "editorPasswordTitle": "Enter editor password",
+    "editorPasswordPlaceholder": "Enter password",
+    "editorPasswordWrong": "Wrong password, try again",
+    "editorPasswordConfirm": "Enter Editor"
   },
   "Metadata": {
     "title": "Luoyuan Bouldering TOPO",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -283,7 +283,13 @@
     "feedbackThanks": "Merci pour votre retour 💚",
     "donate": "Offrez-moi un café ☕️",
     "avatarAlt": "Avatar de l'auteur",
-    "donateAlt": "Code QR de don"
+    "donateAlt": "Code QR de don",
+    "editorEntry": "Éditeur Topo",
+    "editorEntryHint": "Mot de passe requis",
+    "editorPasswordTitle": "Entrez le mot de passe",
+    "editorPasswordPlaceholder": "Entrez le mot de passe",
+    "editorPasswordWrong": "Mot de passe incorrect, réessayez",
+    "editorPasswordConfirm": "Accéder à l'éditeur"
   },
   "Metadata": {
     "title": "Luoyuan Bouldering TOPO",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -315,7 +315,13 @@
     "feedbackThanks": "感谢你的留言 💚",
     "donate": "给小傅买杯咖啡 ☕️",
     "avatarAlt": "作者头像",
-    "donateAlt": "赞赏码"
+    "donateAlt": "赞赏码",
+    "editorEntry": "Topo 编辑器",
+    "editorEntryHint": "需要密码访问",
+    "editorPasswordTitle": "输入编辑器密码",
+    "editorPasswordPlaceholder": "请输入密码",
+    "editorPasswordWrong": "密码错误，请重试",
+    "editorPasswordConfirm": "进入编辑器"
   },
   "Metadata": {
     "title": "罗源野抱 TOPO",

--- a/src/app/[locale]/profile/page.tsx
+++ b/src/app/[locale]/profile/page.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-import { useState, useCallback, useEffect } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 import Image from 'next/image'
 import { useTranslations } from 'next-intl'
-import { Palette, Heart, Copy, Check, User, Send, Users, Globe } from 'lucide-react'
+import { useRouter } from '@/i18n/navigation'
+import { Palette, Heart, Copy, Check, User, Send, Users, Globe, Lock } from 'lucide-react'
 import { AppTabbar } from '@/components/app-tabbar'
 import { ThemeSwitcher } from '@/components/theme-switcher'
 import { LocaleSegmented } from '@/components/locale-switcher'
@@ -47,6 +48,13 @@ export default function ProfilePage() {
 
   // 访问统计状态
   const [totalVisits, setTotalVisits] = useState<number | null>(null)
+
+  // 编辑器入口状态
+  const router = useRouter()
+  const [editorDrawerOpen, setEditorDrawerOpen] = useState(false)
+  const [editorPassword, setEditorPassword] = useState('')
+  const [editorPasswordError, setEditorPasswordError] = useState(false)
+  const passwordInputRef = useRef<HTMLInputElement>(null)
 
   // 获取访问统计
   useEffect(() => {
@@ -123,6 +131,20 @@ export default function ProfilePage() {
       setTimeout(() => setCopiedField(null), 2000)
     }
   }, [])
+
+  // 编辑器密码验证
+  const handleEditorPasswordSubmit = useCallback(() => {
+    if (editorPassword === '1243') {
+      setEditorDrawerOpen(false)
+      setEditorPassword('')
+      setEditorPasswordError(false)
+      router.push('/editor')
+    } else {
+      setEditorPasswordError(true)
+      setEditorPassword('')
+      passwordInputRef.current?.focus()
+    }
+  }, [editorPassword, router])
 
   return (
     <>
@@ -228,6 +250,38 @@ export default function ProfilePage() {
                 )}
               </p>
             </div>
+          </div>
+
+          {/* 编辑器入口 */}
+          <div className="mb-6">
+            <button
+              onClick={() => {
+                setEditorDrawerOpen(true)
+                setEditorPassword('')
+                setEditorPasswordError(false)
+              }}
+              className="w-full flex items-center gap-4 p-4 transition-all active:scale-[0.98]"
+              style={{
+                backgroundColor: 'var(--theme-surface)',
+                borderRadius: 'var(--theme-radius-xl)',
+                boxShadow: 'var(--theme-shadow-sm)',
+              }}
+            >
+              <div
+                className="w-10 h-10 rounded-full flex items-center justify-center"
+                style={{ backgroundColor: 'color-mix(in srgb, var(--theme-primary) 15%, var(--theme-surface))' }}
+              >
+                <Lock className="w-5 h-5" style={{ color: 'var(--theme-primary)' }} />
+              </div>
+              <div className="flex-1 text-left">
+                <p className="text-base font-medium" style={{ color: 'var(--theme-on-surface)' }}>
+                  {t('editorEntry')}
+                </p>
+                <p className="text-xs" style={{ color: 'var(--theme-on-surface-variant)' }}>
+                  {t('editorEntryHint')}
+                </p>
+              </div>
+            </button>
           </div>
 
           {/* 版本信息 */}
@@ -404,6 +458,74 @@ export default function ProfilePage() {
             <Heart className="w-5 h-5" fill="white" />
             <span className="font-medium">{t('donate')}</span>
           </button>
+        </div>
+      </Drawer>
+
+      {/* 编辑器密码抽屉 */}
+      <Drawer
+        isOpen={editorDrawerOpen}
+        onClose={() => setEditorDrawerOpen(false)}
+        height="auto"
+        showHandle
+      >
+        <div className="px-4 pb-6">
+          <div className="flex flex-col items-center mb-4">
+            <div
+              className="w-12 h-12 rounded-full flex items-center justify-center mb-3"
+              style={{ backgroundColor: 'color-mix(in srgb, var(--theme-primary) 15%, var(--theme-surface))' }}
+            >
+              <Lock className="w-6 h-6" style={{ color: 'var(--theme-primary)' }} />
+            </div>
+            <h2
+              className="text-lg font-bold"
+              style={{ color: 'var(--theme-on-surface)' }}
+            >
+              {t('editorPasswordTitle')}
+            </h2>
+          </div>
+          <form
+            onSubmit={(e) => {
+              e.preventDefault()
+              handleEditorPasswordSubmit()
+            }}
+          >
+            <input
+              ref={passwordInputRef}
+              type="password"
+              inputMode="numeric"
+              value={editorPassword}
+              onChange={(e) => {
+                setEditorPassword(e.target.value)
+                setEditorPasswordError(false)
+              }}
+              placeholder={t('editorPasswordPlaceholder')}
+              autoFocus
+              className="w-full p-3 text-center text-lg tracking-widest outline-none mb-3"
+              style={{
+                backgroundColor: 'var(--theme-surface-variant)',
+                color: 'var(--theme-on-surface)',
+                borderRadius: 'var(--theme-radius-lg)',
+                border: editorPasswordError ? '2px solid var(--theme-error)' : '2px solid transparent',
+              }}
+            />
+            {editorPasswordError && (
+              <p className="text-xs text-center mb-3" style={{ color: 'var(--theme-error)' }}>
+                {t('editorPasswordWrong')}
+              </p>
+            )}
+            <button
+              type="submit"
+              disabled={!editorPassword.trim()}
+              className="w-full p-3 font-medium transition-all active:scale-[0.98] disabled:opacity-40"
+              style={{
+                backgroundColor: 'var(--theme-primary)',
+                color: 'var(--theme-on-primary)',
+                borderRadius: 'var(--theme-radius-lg)',
+              }}
+            >
+              {t('editorPasswordConfirm')}
+            </button>
+          </form>
         </div>
       </Drawer>
 

--- a/src/components/app-tabbar.tsx
+++ b/src/components/app-tabbar.tsx
@@ -1,8 +1,7 @@
 'use client'
 
-import { useCallback } from 'react'
 import { useTranslations } from 'next-intl'
-import { Link, usePathname, useRouter } from '@/i18n/navigation'
+import { Link, usePathname } from '@/i18n/navigation'
 import { Home, Mountain, Settings } from 'lucide-react'
 
 // 导航项配置 - label 使用翻译键
@@ -12,55 +11,9 @@ const TAB_ITEMS = [
   { name: 'settings', path: '/profile', icon: Settings, labelKey: 'settings' },
 ] as const
 
-// 隐藏入口配置
-const SECRET_TAP_COUNT = 6        // 需要点击的次数
-const SECRET_TAP_TIMEOUT = 2000   // 时间窗口 (ms)
-const SECRET_STORAGE_KEY = '_secret_tap'
-
 export function AppTabbar() {
   const t = useTranslations('Navigation')
   const pathname = usePathname()
-  const router = useRouter()
-
-  // 隐藏入口：连续点击"线路"按钮 6 次打开编辑器
-  // 使用 sessionStorage 持久化计数（因为 Link 点击会导致组件重新挂载）
-  const handleSecretTap = useCallback((e: React.MouseEvent) => {
-    const now = Date.now()
-
-    // 从 sessionStorage 读取状态
-    let tapCount = 0
-    let lastTapTime = 0
-    try {
-      const stored = sessionStorage.getItem(SECRET_STORAGE_KEY)
-      if (stored) {
-        const data = JSON.parse(stored)
-        tapCount = data.count || 0
-        lastTapTime = data.time || 0
-      }
-    } catch {
-      // 忽略解析错误
-    }
-
-    // 如果距离上次点击超过时间窗口，重置计数
-    if (now - lastTapTime > SECRET_TAP_TIMEOUT) {
-      tapCount = 0
-    }
-
-    tapCount += 1
-
-    // 达到目标次数，跳转到编辑器
-    if (tapCount >= SECRET_TAP_COUNT) {
-      e.preventDefault() // 阻止 Link 默认导航
-      sessionStorage.removeItem(SECRET_STORAGE_KEY)
-      router.push('/editor')
-    } else {
-      // 保存状态到 sessionStorage
-      sessionStorage.setItem(SECRET_STORAGE_KEY, JSON.stringify({
-        count: tapCount,
-        time: now,
-      }))
-    }
-  }, [router])
 
   const isActive = (path: string) => {
     if (path === '/') return pathname === '/'
@@ -80,14 +33,12 @@ export function AppTabbar() {
         {TAB_ITEMS.map((tab) => {
           const Icon = tab.icon
           const active = isActive(tab.path)
-          const isRoutesTab = tab.name === 'routes'
 
           return (
             <Link
               key={tab.name}
               href={tab.path}
               className="relative flex flex-col items-center justify-center flex-1 h-full group active:scale-95 transition-transform"
-              onClick={isRoutesTab ? handleSecretTap : undefined}
             >
               {/* 图标容器 + 选中状态背景指示器 */}
               <div className="relative flex items-center justify-center w-16 h-8 mb-1">


### PR DESCRIPTION
## Summary
- Replace hidden 6-tap easter egg on routes tab with explicit editor entry on settings page
- Add password drawer UI (password: "1243") to access topo editor
- Add i18n translations for zh/en/fr

## Test plan
- [x] Open settings page, verify "Topo 编辑器" button appears
- [x] Click button, verify password drawer opens
- [x] Enter wrong password, verify error message
- [ ] Enter "1243", verify navigation to /editor
- [ ] Verify routes tab no longer has easter egg behavior

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)