### PR TITLE
refactor: simplify grade selector to range-only mode

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -59,7 +59,7 @@
     "allRoutes": "All Routes",
     "allGrades": "All Grades",
     "selectedGrades": "{count, plural, =1 {# grade selected} other {# grades selected}}",
-    "gradeHint": "Tap to toggle, drag to select range",
+    "gradeHint": "Tap or drag to select grade range",
     "filterTitle": "Filter Routes",
     "cragLabel": "Crag",
     "gradeMultiSelect": "Grade (multi-select)",
@@ -338,7 +338,7 @@
     "profileEntry": "App Introduction",
     "profileEntryHint": "Learn about features and how to use",
     "hintPinchZoom": "Pinch to zoom and see route details",
-    "hintSearch": "Search by route name or grade",
+    "hintSearch": "Search by route name, pinyin supported",
     "backToHome": "Back to Home"
   },
   "Metadata": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -59,7 +59,7 @@
     "allRoutes": "Toutes les voies",
     "allGrades": "Toutes les cotations",
     "selectedGrades": "{count, plural, =1 {# cotation sélectionnée} other {# cotations sélectionnées}}",
-    "gradeHint": "Appuyez pour basculer, glissez pour sélectionner une plage",
+    "gradeHint": "Appuyez ou glissez pour sélectionner une plage",
     "filterTitle": "Filtrer les voies",
     "cragLabel": "Site",
     "gradeMultiSelect": "Cotation (multi-sélection)",
@@ -306,7 +306,7 @@
     "profileEntry": "Présentation de l'app",
     "profileEntryHint": "Découvrir les fonctionnalités",
     "hintPinchZoom": "Pincez pour zoomer et voir les détails",
-    "hintSearch": "Recherchez par nom de voie ou cotation",
+    "hintSearch": "Recherchez par nom de voie, pinyin pris en charge",
     "backToHome": "Retour à l'accueil"
   },
   "Metadata": {

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -59,7 +59,7 @@
     "allRoutes": "全部线路",
     "allGrades": "全部难度",
     "selectedGrades": "已选 {count} 个难度",
-    "gradeHint": "点击切换单个难度，拖动选择范围",
+    "gradeHint": "点击或拖动选择难度范围",
     "filterTitle": "筛选线路",
     "cragLabel": "岩场",
     "gradeMultiSelect": "难度（可多选）",
@@ -338,7 +338,7 @@
     "profileEntry": "App 介绍",
     "profileEntryHint": "了解功能和使用方式",
     "hintPinchZoom": "双指缩放查看线路细节",
-    "hintSearch": "支持按线路名或难度搜索",
+    "hintSearch": "支持按线路名搜索，也支持拼音",
     "backToHome": "返回首页"
   },
   "Metadata": {

--- a/src/components/grade-range-selector.ct.tsx
+++ b/src/components/grade-range-selector.ct.tsx
@@ -1,15 +1,14 @@
 /**
  * GradeRangeSelector Playwright 组件测试
  * 测试需要真实浏览器环境的复杂交互：
- * - 单击切换选择
+ * - 点选单个等级
  * - 拖动范围选择
- * - 复合选择（不连续多选）
  */
 import { test, expect } from '@playwright/experimental-ct-react'
 import { GradeRangeSelector } from './grade-range-selector'
 
 test.describe('GradeRangeSelector 真实交互测试', () => {
-  test('单击应切换单个难度的选择状态', async ({ mount }) => {
+  test('单击应选中单个难度', async ({ mount }) => {
     let selectedGrades: string[] = []
 
     const component = await mount(
@@ -87,18 +86,6 @@ test.describe('GradeRangeSelector 真实交互测试', () => {
 
     // 验证显示"全部难度"
     await expect(component.getByText('全部难度')).toBeVisible()
-  })
-
-  test('不连续选择应显示选中数量', async ({ mount }) => {
-    const component = await mount(
-      <GradeRangeSelector
-        selectedGrades={['V0', 'V5', 'V10']}
-        onChange={() => {}}
-      />
-    )
-
-    // 验证显示选中数量
-    await expect(component.getByText('已选 3 个难度')).toBeVisible()
   })
 
   test('应渲染所有 14 个难度等级', async ({ mount }) => {

--- a/src/components/grade-range-selector.test.tsx
+++ b/src/components/grade-range-selector.test.tsx
@@ -1,7 +1,7 @@
 /**
  * GradeRangeSelector 组件测试
  * 测试难度色谱条的交互行为：
- * - 单击切换（toggle）
+ * - 点选单个等级
  * - 拖动范围选择
  * - 清除选择
  * - 显示状态
@@ -44,7 +44,6 @@ describe('GradeRangeSelector', () => {
         />
       )
 
-      // 使用翻译键匹配
       expect(screen.getByText('allGrades')).toBeInTheDocument()
     })
 
@@ -70,18 +69,6 @@ describe('GradeRangeSelector', () => {
       expect(screen.getByText('V2 - V5')).toBeInTheDocument()
     })
 
-    it('不连续选择时应显示选中数量', () => {
-      render(
-        <GradeRangeSelector
-          selectedGrades={['V0', 'V5', 'V10']}
-          onChange={mockOnChange}
-        />
-      )
-
-      // 使用翻译键匹配（参数会被替换）
-      expect(screen.getByText(/selectedGrades/i)).toBeInTheDocument()
-    })
-
     it('有选择时应显示清除按钮', () => {
       render(
         <GradeRangeSelector
@@ -90,7 +77,6 @@ describe('GradeRangeSelector', () => {
         />
       )
 
-      // 使用翻译键匹配
       expect(screen.getByText('clear')).toBeInTheDocument()
     })
 
@@ -106,16 +92,15 @@ describe('GradeRangeSelector', () => {
     })
   })
 
-  describe('单击交互', () => {
+  describe('交互', () => {
     /**
      * 注意：以下测试需要真实浏览器环境（Playwright）
      * 因为 jsdom 中 getBoundingClientRect() 返回 { width: 0, height: 0 }
      * 导致位置计算无法正常工作
      *
      * 在 Playwright 组件测试中应覆盖：
-     * - 单击切换选择
+     * - 点选单个等级
      * - 拖动范围选择
-     * - 复合选择
      */
 
     it('色谱条容器应支持鼠标事件', () => {
@@ -126,7 +111,6 @@ describe('GradeRangeSelector', () => {
         />
       )
 
-      // 验证色谱条容器存在且可交互
       const colorBar = container.querySelector('.touch-none')
       expect(colorBar).toBeInTheDocument()
       expect(colorBar).toHaveClass('cursor-pointer')
@@ -143,16 +127,14 @@ describe('GradeRangeSelector', () => {
       const colorBar = container.querySelector('.touch-none')
       expect(colorBar).toBeInTheDocument()
 
-      // 验证触摸事件可以触发
       fireEvent.touchStart(colorBar!, {
         touches: [{ clientX: 100, clientY: 0 }],
       })
 
-      // 组件应进入拖动状态（内部状态，这里只验证不报错）
       fireEvent.touchEnd(colorBar!)
     })
 
-    it('mouseDown 应触发交互流程', () => {
+    it('mouseDown + mouseUp 应触发 onChange', () => {
       const { container } = render(
         <GradeRangeSelector
           selectedGrades={[]}
@@ -162,12 +144,9 @@ describe('GradeRangeSelector', () => {
 
       const colorBar = container.querySelector('.touch-none')
 
-      // mouseDown 后 mouseUp 应触发 onChange
-      // 虽然在 jsdom 中位置计算有问题，但交互流程应该正常
       fireEvent.mouseDown(colorBar!, { clientX: 0 })
       fireEvent.mouseUp(colorBar!)
 
-      // 应该调用 onChange（位置可能不正确，但流程正常）
       expect(mockOnChange).toHaveBeenCalled()
     })
   })
@@ -181,7 +160,6 @@ describe('GradeRangeSelector', () => {
         />
       )
 
-      // 使用翻译键匹配
       const clearButton = screen.getByText('clear')
       fireEvent.click(clearButton)
 
@@ -198,7 +176,6 @@ describe('GradeRangeSelector', () => {
         />
       )
 
-      // 使用翻译键匹配
       expect(screen.getByText('gradeHint')).toBeInTheDocument()
     })
   })


### PR DESCRIPTION
## Summary
- Remove single-click toggle and discontinuous multi-select from `GradeRangeSelector`
- Tap now selects a single grade; drag selects a contiguous range
- Removed `toggleGrade` function and discontinuous display logic from `getRangeText`
- Updated i18n hint text (zh/en/fr) to reflect simplified interaction
- Updated Vitest and Playwright tests (removed discontinuous selection test)

Closes #123

## Test plan
- [x] `npm run lint` passes
- [x] `npm run test:run` — 601 tests pass (1 removed: discontinuous selection)
- [ ] Manual: tap a grade → single grade selected
- [ ] Manual: drag across grades → contiguous range selected
- [ ] Manual: clear button works

🤖 Generated with [Claude Code](https://claude.com/claude-code)