### PR TITLE
fix(input): use CompositionInput for all Chinese text inputs

### DIFF
--- a/src/app/[locale]/editor/faces/page.tsx
+++ b/src/app/[locale]/editor/faces/page.tsx
@@ -659,10 +659,10 @@ export default function FaceManagementPage() {
             <div className="flex items-center justify-between mb-3 gap-2">
               {isRenaming ? (
                 <div className="flex items-center gap-2 flex-1 min-w-0">
-                  <input
+                  <CompositionInput
                     type="text"
                     value={renameValue}
-                    onChange={(e) => setRenameValue(e.target.value.toLowerCase().replace(/[^\u4e00-\u9fffa-z0-9-]/g, ''))}
+                    onChange={(value) => setRenameValue(value.toLowerCase().replace(/[^\u4e00-\u9fffa-z0-9-]/g, ''))}
                     onKeyDown={(e) => { if (e.key === 'Enter') handleRenameFace(); if (e.key === 'Escape') setIsRenaming(false) }}
                     autoFocus
                     className="flex-1 min-w-0 px-3 py-1.5 rounded-lg text-sm font-semibold outline-none focus:ring-2 focus:ring-[var(--theme-primary)]"

--- a/src/app/[locale]/profile/page.tsx
+++ b/src/app/[locale]/profile/page.tsx
@@ -11,6 +11,7 @@ import { ThemeSwitcher } from '@/components/theme-switcher'
 import { LocaleSegmented } from '@/components/locale-switcher'
 import { OfflineCacheSection } from '@/components/offline-cache-manager'
 import { Drawer } from '@/components/ui/drawer'
+import { CompositionTextarea } from '@/components/ui/composition-input'
 import { ImageViewer } from '@/components/ui/image-viewer'
 // 访问统计缓存 key
 const VISITS_CACHE_KEY = 'total_visits_cache'
@@ -439,9 +440,9 @@ export default function ProfilePage() {
           {/* 留言区域 */}
           <div className="mb-4">
             <div className="relative">
-              <textarea
+              <CompositionTextarea
                 value={feedbackContent}
-                onChange={(e) => setFeedbackContent(e.target.value)}
+                onChange={(value) => setFeedbackContent(value)}
                 placeholder={t('feedbackPlaceholder')}
                 maxLength={500}
                 rows={3}

--- a/src/app/[locale]/route/route-client.tsx
+++ b/src/app/[locale]/route/route-client.tsx
@@ -9,6 +9,7 @@ import { FILTER_PARAMS, getGradesByValues, DEFAULT_SORT_DIRECTION, type SortDire
 import { compareGrades } from '@/lib/grade-utils'
 import { getSiblingRoutes } from '@/lib/route-utils'
 import { matchRouteByQuery } from '@/hooks/use-route-search'
+import { CompositionInput } from '@/components/ui/composition-input'
 import { FilterChip, FilterChipGroup } from '@/components/filter-chip'
 import { GradeRangeSelector } from '@/components/grade-range-selector'
 import { RouteDetailDrawer } from '@/components/route-detail-drawer'
@@ -206,11 +207,11 @@ export default function RouteListClient({ routes, crags }: RouteListClientProps)
               className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4"
               style={{ color: 'var(--theme-on-surface-variant)' }}
             />
-            <input
+            <CompositionInput
               type="text"
               placeholder={tSearch('placeholder')}
               value={searchQuery}
-              onChange={(e) => handleSearchChange(e.target.value)}
+              onChange={(value) => handleSearchChange(value)}
               className="w-full h-10 pl-10 pr-10 text-sm focus:outline-none"
               style={{
                 backgroundColor: 'var(--theme-surface-variant)',

--- a/src/components/search-drawer.tsx
+++ b/src/components/search-drawer.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from 'next-intl'
 import { useRouter } from '@/i18n/navigation'
 import { Search, X, ChevronRight, ArrowRight, SlidersHorizontal, Video, User } from 'lucide-react'
 import { Drawer } from '@/components/ui/drawer'
+import { CompositionInput } from '@/components/ui/composition-input'
 import { ContextualHint } from '@/components/contextual-hint'
 import { RouteDetailDrawer } from '@/components/route-detail-drawer'
 import { getGradeColor } from '@/lib/tokens'
@@ -104,12 +105,12 @@ export function SearchDrawer({
               className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4"
               style={{ color: 'var(--theme-on-surface-variant)' }}
             />
-            <input
+            <CompositionInput
               ref={inputRef}
               type="text"
               placeholder={t('placeholder')}
               value={searchQuery}
-              onChange={(e) => onSearchChange(e.target.value)}
+              onChange={(value) => onSearchChange(value)}
               className="w-full h-11 pl-10 pr-10 text-sm focus:outline-none"
               style={{
                 backgroundColor: 'var(--theme-surface-variant)',

--- a/src/components/search-overlay.tsx
+++ b/src/components/search-overlay.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef } from 'react'
 import { useTranslations } from 'next-intl'
 import { useRouter } from '@/i18n/navigation'
 import { Search, X, ChevronRight } from 'lucide-react'
+import { CompositionInput } from '@/components/ui/composition-input'
 import type { Route } from '@/types'
 import { getGradeColor } from '@/lib/tokens'
 
@@ -80,12 +81,12 @@ export function SearchOverlay({
               className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4"
               style={{ color: 'var(--theme-on-surface-variant)' }}
             />
-            <input
+            <CompositionInput
               ref={inputRef}
               type="text"
               placeholder={t('placeholder')}
               value={searchQuery}
-              onChange={(e) => onSearchChange(e.target.value)}
+              onChange={(value) => onSearchChange(value)}
               className="w-full h-10 pl-10 pr-10 text-sm focus:outline-none"
               style={{
                 backgroundColor: 'var(--theme-surface-variant)',


### PR DESCRIPTION
## Summary

- 将 5 个组件中的原生 `<input>`/`<textarea>` 替换为 `CompositionInput`/`CompositionTextarea`，修复中文输入法在组合期间被 React 状态更新打断的问题
- 影响：岩面重命名、搜索框（3处）、留言框

## 修改文件

| 文件 | 修改内容 |
|------|---------|
| `editor/faces/page.tsx` | 岩面重命名 input → CompositionInput |
| `search-drawer.tsx` | 搜索 input → CompositionInput |
| `search-overlay.tsx` | 搜索 input → CompositionInput |
| `route-client.tsx` | 搜索 input → CompositionInput |
| `profile/page.tsx` | 留言 textarea → CompositionTextarea |

## Test plan

- [ ] 在岩面管理页面测试中文重命名
- [ ] 在首页搜索抽屉中测试中文搜索
- [ ] 在线路页搜索框中测试中文搜索
- [ ] 在个人页留言框中测试中文输入

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)