### PR TITLE
fix(route): filter UX improvements (5 fixes)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,28 @@
+#!/usr/bin/env sh
+
+# Pre-push hook: run tsc --noEmit against committed-only files
+# Stash uncommitted changes so tsc sees the same code as CI
+
+# Check if there are uncommitted changes to stash
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  git stash push --keep-index --include-untracked -q -m "pre-push-hook"
+  STASHED=1
+else
+  STASHED=0
+fi
+
+echo "🔍 Running TypeScript check before push..."
+npx tsc --noEmit
+TSC_EXIT=$?
+
+# Restore stashed changes
+if [ "$STASHED" = "1" ]; then
+  git stash pop -q
+fi
+
+if [ $TSC_EXIT -ne 0 ]; then
+  echo "❌ TypeScript check failed. Push aborted."
+  exit 1
+fi
+
+echo "✅ TypeScript check passed."

--- a/messages/en.json
+++ b/messages/en.json
@@ -68,7 +68,9 @@
     "sortDesc": "Hard→Easy",
     "sortAscHint": "Currently: Easy to Hard, tap to reverse",
     "sortDescHint": "Currently: Hard to Easy, tap to reverse",
-    "totalCount": "{count, plural, =1 {# route total} other {# routes total}}"
+    "totalCount": "{count, plural, =1 {# route total} other {# routes total}}",
+    "clearFilters": "Clear all filters",
+    "faceHint": "Select a crag to filter by rock face"
   },
   "RouteDetail": {
     "grade": "Grade",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -68,7 +68,9 @@
     "sortDesc": "Difficile→Facile",
     "sortAscHint": "Actuellement : Facile à Difficile, appuyez pour inverser",
     "sortDescHint": "Actuellement : Difficile à Facile, appuyez pour inverser",
-    "totalCount": "{count, plural, =1 {# voie au total} other {# voies au total}}"
+    "totalCount": "{count, plural, =1 {# voie au total} other {# voies au total}}",
+    "clearFilters": "Effacer tous les filtres",
+    "faceHint": "Sélectionnez un site pour filtrer par face"
   },
   "RouteDetail": {
     "grade": "Cotation",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -68,7 +68,9 @@
     "sortDesc": "难→简单",
     "sortAscHint": "当前：从简单到难，点击反转",
     "sortDescHint": "当前：从难到简单，点击反转",
-    "totalCount": "共 {count} 条线路"
+    "totalCount": "共 {count} 条线路",
+    "clearFilters": "清除所有筛选",
+    "faceHint": "选择岩场后可按岩面筛选"
   },
   "RouteDetail": {
     "grade": "难度",

--- a/src/components/floating-search-input.tsx
+++ b/src/components/floating-search-input.tsx
@@ -44,6 +44,11 @@ export function FloatingSearchInput({
           themed={false}
           value={value}
           onChange={onChange}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              inputRef.current?.blur()
+            }
+          }}
           placeholder={placeholder}
           className="w-full h-full bg-transparent pl-12 pr-10 text-sm outline-none"
           style={{ color: 'var(--theme-on-surface)' }}


### PR DESCRIPTION
## Summary
- ❶ Enter in search only dismisses keyboard, keeps query
- ❷ Active filter tags shown below route count (tap X to remove individual filter)
- ❸ "All" chip resets all filters (crag, face, grade, search)
- ❹ Hint text shown when no crag selected ("选择岩场后可按岩面筛选")
- ❺ "Clear all filters" button on empty results
- 🔧 Added `.husky/pre-push` hook (runs `tsc --noEmit` before push)

## Test plan
- [ ] 搜索输入后按 Enter → 键盘收起，搜索词保留
- [ ] 选择难度+搜索 → filter tags 显示，点击 X 可单独移除
- [ ] 点击 "全部" chip → 所有筛选重置
- [ ] 未选岩场 → 显示 "选择岩场后可按岩面筛选" 提示
- [ ] 筛选到 0 结果 → 显示 "清除所有筛选" 按钮
- [ ] `git push` 时自动运行 TypeScript 检查

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)