### PR TITLE
fix(route): grade filter tag shows range instead of count

### DIFF
--- a/src/app/[locale]/route/route-client.tsx
+++ b/src/app/[locale]/route/route-client.tsx
@@ -171,9 +171,11 @@ export default function RouteListClient({ routes, crags }: RouteListClientProps)
       })
     }
     if (selectedGrades.length > 0) {
+      // 显示难度范围：≤3 个列出全部，>3 个显示首尾范围如 "V2–V7"
+      const sorted = [...selectedGrades].sort((a, b) => compareGrades(a, b))
       const label = selectedGrades.length <= 3
-        ? selectedGrades.join(', ')
-        : `${selectedGrades.length} ${t('selectedGrades', { count: selectedGrades.length }).replace(/^已选 \d+ 个/, '')}`
+        ? sorted.join(', ')
+        : `${sorted[0]}–${sorted[sorted.length - 1]}`
       tags.push({
         label,
         onRemove: () => updateSearchParams(FILTER_PARAMS.GRADE, null),


### PR DESCRIPTION
## Summary
- Grade filter tag now shows `V2–V7` (range) instead of `5 难度` (count)
- ≤3 grades: listed individually (`V3, V5, V8`)
- \>3 grades: sorted range (`V2–V7`)

## Test plan
- [ ] 选 1-3 个难度 → tag 显示如 `V3, V5`
- [ ] 选 4+ 个难度 → tag 显示如 `V2–V7`

🤖 Generated with [Claude Code](https://claude.com/claude-code)