### PR TITLE
fix: clear stale data when switching crags

### DIFF
--- a/src/app/[locale]/editor/faces/page.tsx
+++ b/src/app/[locale]/editor/faces/page.tsx
@@ -134,6 +134,7 @@ export default function FaceManagementPage() {
       setR2Faces([])
       return
     }
+    setR2Faces([])
     let cancelled = false
     loadFaces(selectedCragId).then(() => { if (cancelled) return })
     return () => { cancelled = true }

--- a/src/hooks/use-crag-routes.ts
+++ b/src/hooks/use-crag-routes.ts
@@ -41,6 +41,7 @@ export function useCragRoutes() {
       return
     }
 
+    setRoutes([])
     async function loadRoutes() {
       setIsLoadingRoutes(true)
       try {


### PR DESCRIPTION
## Summary
- Clear routes array when switching crags in `useCragRoutes` hook
- Clear R2 faces list when switching crags in face editor page
- Prevents stale data flash before new data loads

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)