### PR TITLE
feat(editor): auto-compress large images before upload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@aws-sdk/client-s3": "^3.975.0",
         "@radix-ui/react-slot": "^1.2.4",
         "@serwist/next": "^9.5.0",
+        "browser-image-compression": "^2.0.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.562.0",
@@ -6941,6 +6942,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/browser-image-compression": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
+      "license": "MIT",
+      "dependencies": {
+        "uzip": "0.20201231.0"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
@@ -12478,6 +12488,12 @@
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng==",
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "7.3.1",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@aws-sdk/client-s3": "^3.975.0",
     "@radix-ui/react-slot": "^1.2.4",
     "@serwist/next": "^9.5.0",
+    "browser-image-compression": "^2.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.562.0",


### PR DESCRIPTION
## Summary
- Add `browser-image-compression` for client-side image compression
- Auto-compress images >5MB to ≤4MB before uploading (max 4096px)
- Show compression progress bar UI in both "create face" and "replace photo" buttons

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)