### PR TITLE
refactor(editor): extract deriveAreas and fix stale area filtering

### DIFF
--- a/src/app/[locale]/editor/faces/page.tsx
+++ b/src/app/[locale]/editor/faces/page.tsx
@@ -26,6 +26,7 @@ import { useToast } from '@/components/ui/toast'
 import { useCragRoutes } from '@/hooks/use-crag-routes'
 import { CragSelector } from '@/components/editor/crag-selector'
 import { preloadImage } from '@/lib/editor-utils'
+import { deriveAreas } from '@/lib/editor-areas'
 
 interface R2FaceInfo {
   faceId: string
@@ -171,11 +172,10 @@ export default function FaceManagementPage() {
 
   // ============ 派生数据 ============
   const selectedCrag = useMemo(() => crags.find(c => c.id === selectedCragId), [crags, selectedCragId])
-  const areas = useMemo(() => {
-    const routeAreas = routes.map(r => r.area).filter(Boolean)
-    const cragAreas = selectedCrag?.areas ?? []
-    return [...new Set([...cragAreas, ...routeAreas])].sort()
-  }, [routes, selectedCrag])
+  const areas = useMemo(
+    () => deriveAreas(routes, selectedCragId, selectedCrag),
+    [routes, selectedCrag, selectedCragId],
+  )
 
   const faceGroups = useMemo(() => {
     if (!selectedCragId) return []
@@ -318,7 +318,7 @@ export default function FaceManagementPage() {
     } finally {
       setIsUploading(false)
     }
-  }, [uploadedFile, selectedCragId, isCreating, newFaceId, selectedFace, showToast])
+  }, [uploadedFile, selectedCragId, isCreating, newFaceId, selectedFace, newArea, customArea, areas, updateCragAreas, showToast])
 
   const handleUpload = useCallback(async () => {
     if (!uploadedFile || !selectedCragId) return
@@ -349,7 +349,7 @@ export default function FaceManagementPage() {
     }
 
     await doUpload()
-  }, [uploadedFile, selectedCragId, isCreating, newFaceId, selectedFace, doUpload])
+  }, [uploadedFile, selectedCragId, isCreating, newFaceId, newArea, customArea, selectedFace, doUpload])
 
   // ============ 删除岩面 ============
   const handleDeleteFace = useCallback(async () => {

--- a/src/app/[locale]/editor/routes/page.tsx
+++ b/src/app/[locale]/editor/routes/page.tsx
@@ -35,6 +35,7 @@ import { FullscreenTopoEditor } from '@/components/editor/fullscreen-topo-editor
 import { MultiTopoLineOverlay } from '@/components/multi-topo-line-overlay'
 import type { MultiTopoRoute } from '@/components/multi-topo-line-overlay'
 import { VIEW_WIDTH, VIEW_HEIGHT, GRADE_OPTIONS } from '@/lib/editor-utils'
+import { deriveAreas } from '@/lib/editor-areas'
 
 interface R2FaceInfo {
   faceId: string
@@ -142,11 +143,10 @@ export default function RouteAnnotationPage() {
   // ============ 派生数据 ============
   // 合并 crag.areas 与 route 派生 areas
   const selectedCrag = useMemo(() => crags.find(c => c.id === selectedCragId), [crags, selectedCragId])
-  const areas = useMemo(() => {
-    const routeAreas = routes.map(r => r.area).filter(Boolean)
-    const cragAreas = selectedCrag?.areas ?? []
-    return [...new Set([...cragAreas, ...routeAreas])].sort()
-  }, [routes, selectedCrag])
+  const areas = useMemo(
+    () => deriveAreas(routes, selectedCragId, selectedCrag),
+    [routes, selectedCrag, selectedCragId],
+  )
 
   // 按 area 筛选的 face 列表（右栏 face 选择器用）
   // 以 R2 返回的 face 数据为主（自带 area），再关联 routes

--- a/src/lib/editor-areas.test.ts
+++ b/src/lib/editor-areas.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest'
+import { deriveAreas } from './editor-areas'
+import type { Route, Crag } from '@/types'
+
+function makeRoute(overrides: Partial<Route> & { cragId: string; area: string }): Route {
+  return {
+    id: 1,
+    name: 'test',
+    grade: 'V0',
+    ...overrides,
+  }
+}
+
+function makeCrag(overrides: Partial<Crag> & { id: string }): Crag {
+  return {
+    name: 'Test Crag',
+    cityId: 'test',
+    location: '',
+    developmentTime: '',
+    description: '',
+    approach: '',
+    ...overrides,
+  }
+}
+
+describe('deriveAreas', () => {
+  it('returns empty array when no crag selected', () => {
+    const routes = [makeRoute({ cragId: 'a', area: '区域1' })]
+    expect(deriveAreas(routes, null, undefined)).toEqual([])
+  })
+
+  it('returns only areas from routes matching selectedCragId', () => {
+    const routes = [
+      makeRoute({ id: 1, cragId: 'crag-a', area: '区域A' }),
+      makeRoute({ id: 2, cragId: 'crag-b', area: '区域B' }),
+      makeRoute({ id: 3, cragId: 'crag-a', area: '区域C' }),
+    ]
+    const result = deriveAreas(routes, 'crag-a', makeCrag({ id: 'crag-a' }))
+    expect(result).toEqual(['区域A', '区域C'])
+    expect(result).not.toContain('区域B')
+  })
+
+  it('filters out stale routes from previous crag during transition', () => {
+    // Simulates the race condition: routes still contain old crag data
+    // but selectedCragId has already changed
+    const staleRoutes = [
+      makeRoute({ id: 1, cragId: 'old-crag', area: '旧区域1' }),
+      makeRoute({ id: 2, cragId: 'old-crag', area: '旧区域2' }),
+    ]
+    const newCrag = makeCrag({ id: 'new-crag', areas: ['新区域'] })
+    const result = deriveAreas(staleRoutes, 'new-crag', newCrag)
+    expect(result).toEqual(['新区域'])
+    expect(result).not.toContain('旧区域1')
+    expect(result).not.toContain('旧区域2')
+  })
+
+  it('merges crag.areas with route-derived areas without duplicates', () => {
+    const routes = [
+      makeRoute({ id: 1, cragId: 'c1', area: '区域A' }),
+      makeRoute({ id: 2, cragId: 'c1', area: '区域B' }),
+    ]
+    const crag = makeCrag({ id: 'c1', areas: ['区域A', '区域C'] })
+    const result = deriveAreas(routes, 'c1', crag)
+    expect(result).toEqual(['区域A', '区域B', '区域C'])
+  })
+
+  it('returns sorted areas', () => {
+    const routes = [
+      makeRoute({ id: 1, cragId: 'c1', area: 'C区' }),
+      makeRoute({ id: 2, cragId: 'c1', area: 'A区' }),
+    ]
+    const crag = makeCrag({ id: 'c1', areas: ['B区'] })
+    expect(deriveAreas(routes, 'c1', crag)).toEqual(['A区', 'B区', 'C区'])
+  })
+
+  it('skips routes with empty area', () => {
+    const routes = [
+      makeRoute({ id: 1, cragId: 'c1', area: '' }),
+      makeRoute({ id: 2, cragId: 'c1', area: '有效区域' }),
+    ]
+    expect(deriveAreas(routes, 'c1', makeCrag({ id: 'c1' }))).toEqual(['有效区域'])
+  })
+
+  it('returns crag.areas even when routes is empty', () => {
+    const crag = makeCrag({ id: 'c1', areas: ['预设区域'] })
+    expect(deriveAreas([], 'c1', crag)).toEqual(['预设区域'])
+  })
+})

--- a/src/lib/editor-areas.ts
+++ b/src/lib/editor-areas.ts
@@ -1,0 +1,19 @@
+import type { Route, Crag } from '@/types'
+
+/**
+ * 从线路列表和岩场配置中派生当前岩场的区域列表
+ * 仅保留属于 selectedCragId 的线路区域，防止切换岩场时残留旧数据
+ */
+export function deriveAreas(
+  routes: Route[],
+  selectedCragId: string | null,
+  selectedCrag: Crag | undefined,
+): string[] {
+  if (!selectedCragId) return []
+  const routeAreas = routes
+    .filter(r => r.cragId === selectedCragId)
+    .map(r => r.area)
+    .filter(Boolean)
+  const cragAreas = selectedCrag?.areas ?? []
+  return [...new Set([...cragAreas, ...routeAreas])].sort()
+}


### PR DESCRIPTION
## Summary
- Extract shared `deriveAreas()` to `src/lib/editor-areas.ts` (used by faces + routes editors)
- Fix bug: stale areas from previous crag appeared during crag switch by filtering on `cragId`
- Fix missing useCallback dependencies in faces editor
- Add 7 unit tests covering edge cases (stale data, dedup, sorting, empty states)

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)