### PR TITLE
perf: parallelize async ops, trim RSC payload, fix Loader2 animation

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -38,6 +38,7 @@ const nextConfig: NextConfig = {
   // 永久路由缓存 - 页面段在客户端缓存 1 年
   // 新版本发布时，Service Worker 更新机制会触发刷新
   experimental: {
+    optimizePackageImports: ['lucide-react'],
     staleTimes: {
       dynamic: 31536000, // 1 年 (秒) - 动态页面
       static: 31536000,  // 1 年 (秒) - 静态页面

--- a/src/app/[locale]/crag/[id]/page.tsx
+++ b/src/app/[locale]/crag/[id]/page.tsx
@@ -40,8 +40,10 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function CragDetailPage({ params }: PageProps) {
   const { id } = await params
-  const crag = await getCragById(id)
-  const routes = await getRoutesByCragId(id)
+  const [crag, routes] = await Promise.all([
+    getCragById(id),
+    getRoutesByCragId(id),
+  ])
 
   if (!crag) {
     notFound()

--- a/src/app/[locale]/editor/faces/page.tsx
+++ b/src/app/[locale]/editor/faces/page.tsx
@@ -540,7 +540,7 @@ export default function FaceManagementPage() {
           <div className="flex-1 overflow-y-auto min-h-0 space-y-2">
             {isLoadingRoutes || isLoadingFaces ? (
               <div className="flex flex-col items-center justify-center py-12" style={{ color: 'var(--theme-on-surface-variant)' }}>
-                <Loader2 className="w-8 h-8 animate-spin mb-3" />
+                <div className="w-8 h-8 animate-spin mb-3"><Loader2 className="w-full h-full" /></div>
                 <span>加载中...</span>
               </div>
             ) : faceGroups.length === 0 ? (
@@ -734,7 +734,7 @@ export default function FaceManagementPage() {
                 </div>
               </div>
             ) : isUploading ? (
-              <><Loader2 className="w-5 h-5 animate-spin" /> 上传中...</>
+              <><div className="w-5 h-5 animate-spin"><Loader2 className="w-full h-full" /></div> 上传中...</>
             ) : (
               <><Upload className="w-5 h-5" /> 创建岩面</>
             )}
@@ -771,7 +771,7 @@ export default function FaceManagementPage() {
                     className="p-1.5 rounded-lg transition-all active:scale-90"
                     style={{ color: 'var(--theme-primary)' }}
                   >
-                    {isSubmittingRename ? <Loader2 className="w-4 h-4 animate-spin" /> : <Check className="w-4 h-4" />}
+                    {isSubmittingRename ? <div className="w-4 h-4 animate-spin"><Loader2 className="w-full h-full" /></div> : <Check className="w-4 h-4" />}
                   </button>
                   <button
                     onClick={() => setIsRenaming(false)}
@@ -888,7 +888,7 @@ export default function FaceManagementPage() {
                       </div>
                     </div>
                   ) : isUploading ? (
-                    <><Loader2 className="w-5 h-5 animate-spin" /> 上传中...</>
+                    <><div className="w-5 h-5 animate-spin"><Loader2 className="w-full h-full" /></div> 上传中...</>
                   ) : (
                     <><Upload className="w-5 h-5" /> 更换照片</>
                   )}
@@ -1048,7 +1048,7 @@ export default function FaceManagementPage() {
                 disabled={isDeleting}
               >
                 {isDeleting ? (
-                  <><Loader2 className="w-4 h-4 animate-spin" /> 删除中...</>
+                  <><div className="w-4 h-4 animate-spin"><Loader2 className="w-full h-full" /></div> 删除中...</>
                 ) : (
                   '确认删除'
                 )}

--- a/src/app/[locale]/editor/routes/page.tsx
+++ b/src/app/[locale]/editor/routes/page.tsx
@@ -428,7 +428,7 @@ export default function RouteAnnotationPage() {
             </label>
             {isLoadingRoutes ? (
               <div className="flex items-center justify-center py-4" style={{ color: 'var(--theme-on-surface-variant)' }}>
-                <Loader2 className="w-5 h-5 animate-spin" />
+                <div className="w-5 h-5 animate-spin"><Loader2 className="w-full h-full" /></div>
               </div>
             ) : (
               <div className="flex gap-2 overflow-x-auto scrollbar-hide pb-2">
@@ -673,7 +673,7 @@ export default function RouteAnnotationPage() {
               }}
             >
               {isSubmittingCreate ? (
-                <><Loader2 className="w-5 h-5 animate-spin" /> 创建中...</>
+                <><div className="w-5 h-5 animate-spin"><Loader2 className="w-full h-full" /></div> 创建中...</>
               ) : (
                 <><Plus className="w-5 h-5" /> 创建线路</>
               )}
@@ -719,7 +719,7 @@ export default function RouteAnnotationPage() {
             </label>
             {isLoadingFaces ? (
               <div className="flex items-center justify-center py-3" style={{ color: 'var(--theme-on-surface-variant)' }}>
-                <Loader2 className="w-5 h-5 animate-spin" />
+                <div className="w-5 h-5 animate-spin"><Loader2 className="w-full h-full" /></div>
               </div>
             ) : areaFaceGroups.length === 0 ? (
               <div className="text-center py-3" style={{ color: 'var(--theme-on-surface-variant)' }}>
@@ -831,7 +831,7 @@ export default function RouteAnnotationPage() {
                   {isImageLoading && (
                     <div className="absolute inset-0 flex items-center justify-center z-10" style={{ backgroundColor: 'var(--theme-surface-variant)' }}>
                       <div className="text-center">
-                        <Loader2 className="w-8 h-8 animate-spin mx-auto mb-2" style={{ color: 'var(--theme-primary)' }} />
+                        <div className="w-8 h-8 animate-spin mx-auto mb-2"><Loader2 className="w-full h-full" style={{ color: 'var(--theme-primary)' }} /></div>
                         <p className="text-sm" style={{ color: 'var(--theme-on-surface-variant)' }}>加载云端图片...</p>
                       </div>
                     </div>
@@ -1025,7 +1025,7 @@ export default function RouteAnnotationPage() {
             disabled={isSaving}
           >
             {isSaving ? (
-              <><Loader2 className="w-5 h-5 animate-spin" /> 保存中...</>
+              <><div className="w-5 h-5 animate-spin"><Loader2 className="w-full h-full" /></div> 保存中...</>
             ) : saveSuccess ? (
               <><Check className="w-5 h-5" /> 保存成功</>
             ) : (

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -21,5 +21,10 @@ export default async function HomePage() {
     getAllRoutes(),
   ])
 
-  return <HomePageClient crags={crags} allRoutes={allRoutes} />
+  // 裁剪 Route 数据，去除首页不需要的大字段 (topoLine, description, image, setter)
+  // 减少 Server→Client RSC payload 大小
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const lightRoutes = allRoutes.map(({ topoLine, description, image, setter, ...rest }) => rest)
+
+  return <HomePageClient crags={crags} allRoutes={lightRoutes} />
 }

--- a/src/components/download-button.tsx
+++ b/src/components/download-button.tsx
@@ -236,7 +236,7 @@ export function DownloadStatusIndicator({
   if (isDownloading) {
     return (
       <div className={cn('flex items-center gap-1 text-xs', className)}>
-        <Loader2 className="w-3 h-3 animate-spin" />
+        <div className="w-3 h-3 animate-spin"><Loader2 className="w-full h-full" /></div>
         <span>{t('downloading')}</span>
       </div>
     )

--- a/src/components/editor/crag-selector.tsx
+++ b/src/components/editor/crag-selector.tsx
@@ -48,7 +48,7 @@ export function CragSelector({
               <Mountain className="w-5 h-5" style={{ color: 'var(--theme-primary)' }} />
               {isLoading ? (
                 <span className="flex items-center gap-2">
-                  <Loader2 className="w-4 h-4 animate-spin" />
+                  <div className="w-4 h-4 animate-spin"><Loader2 className="w-full h-full" /></div>
                   加载中...
                 </span>
               ) : selectedCrag ? (


### PR DESCRIPTION
## Summary
- Parallelize independent async operations (crag page, beta API, faces API)
- Trim RSC payload on homepage by stripping topoLine/description/image/setter from routes
- Add `optimizePackageImports: ['lucide-react']` to reduce bundle size
- Wrap Loader2 SVG in div for reliable CSS animate-spin rendering

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)