### PR TITLE
fix(editor): prevent route-derived areas from leaking into crag.areas

### DIFF
--- a/src/lib/editor-areas.test.ts
+++ b/src/lib/editor-areas.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { deriveAreas } from './editor-areas'
+import { deriveAreas, getPersistedAreas } from './editor-areas'
 import type { Route, Crag } from '@/types'
 
 function makeRoute(overrides: Partial<Route> & { cragId: string; area: string }): Route {
@@ -84,5 +84,21 @@ describe('deriveAreas', () => {
   it('returns crag.areas even when routes is empty', () => {
     const crag = makeCrag({ id: 'c1', areas: ['预设区域'] })
     expect(deriveAreas([], 'c1', crag)).toEqual(['预设区域'])
+  })
+})
+
+describe('getPersistedAreas', () => {
+  it('returns crag.areas when available', () => {
+    const crag = makeCrag({ id: 'c1', areas: ['区域A', '区域B'] })
+    expect(getPersistedAreas(crag)).toEqual(['区域A', '区域B'])
+  })
+
+  it('returns empty array when crag has no areas', () => {
+    const crag = makeCrag({ id: 'c1' })
+    expect(getPersistedAreas(crag)).toEqual([])
+  })
+
+  it('returns empty array when crag is undefined', () => {
+    expect(getPersistedAreas(undefined)).toEqual([])
   })
 })

--- a/src/lib/editor-areas.ts
+++ b/src/lib/editor-areas.ts
@@ -1,8 +1,8 @@
 import type { Route, Crag } from '@/types'
 
 /**
- * 从线路列表和岩场配置中派生当前岩场的区域列表
- * 仅保留属于 selectedCragId 的线路区域，防止切换岩场时残留旧数据
+ * 从线路列表和岩场配置中派生当前岩场的区域列表（用于 UI 显示）
+ * 合并 crag.areas（持久化）和 routes 中的 area（动态派生）
  */
 export function deriveAreas(
   routes: Route[],
@@ -16,4 +16,12 @@ export function deriveAreas(
     .filter(Boolean)
   const cragAreas = selectedCrag?.areas ?? []
   return [...new Set([...cragAreas, ...routeAreas])].sort()
+}
+
+/**
+ * 获取仅持久化的 crag areas（不含 routes 动态派生的部分）
+ * 用于写入 DB 时作为基础，避免将 route 派生 area 意外持久化
+ */
+export function getPersistedAreas(selectedCrag: Crag | undefined): string[] {
+  return selectedCrag?.areas ?? []
 }


### PR DESCRIPTION
## Summary
- Add `getPersistedAreas()` to return only `crag.areas` (DB-backed) without route-derived areas
- Use `persistedAreas` instead of `areas` when writing to DB (updateCragAreas calls)
- Prevents route-derived area names from being accidentally persisted to crag.areas
- Add 3 unit tests for getPersistedAreas

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)