### PR TITLE
fix(ui): reduce excessive top padding in route list page

### DIFF
--- a/src/app/[locale]/route/loading.tsx
+++ b/src/app/[locale]/route/loading.tsx
@@ -23,7 +23,7 @@ export default function RouteListLoading() {
       className="flex flex-col h-screen overflow-hidden"
       style={{ backgroundColor: 'var(--theme-surface)' }}
     >
-      <header className="flex-shrink-0 pt-12 px-4 pb-3">
+      <header className="flex-shrink-0 pt-6 px-4 pb-3">
         <div className="flex items-center gap-3 mb-3">
           <div
             className="h-7 w-24 rounded-md skeleton-shimmer"

--- a/src/app/[locale]/route/route-client.tsx
+++ b/src/app/[locale]/route/route-client.tsx
@@ -232,7 +232,7 @@ export default function RouteListClient({ routes, crags }: RouteListClientProps)
         }}
       >
         {/* 顶部 filter 区域 — 全宽 */}
-        <header className="flex-shrink-0 pt-12 px-4 pb-2">
+        <header className="flex-shrink-0 pt-6 px-4 pb-2">
           <FilterChipGroup>
             <FilterChip
               label={tCommon('all')}


### PR DESCRIPTION
## Summary
- Reduce header top padding from `pt-12` to `pt-6` in route list page
- Applied to both `loading.tsx` and `route-client.tsx` for consistency

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)