### PR TITLE
refactor(route): extract RouteFilterBar and fix face rename sync

### DIFF
--- a/src/app/[locale]/editor/faces/page.tsx
+++ b/src/app/[locale]/editor/faces/page.tsx
@@ -78,7 +78,7 @@ function FaceThumbnail({ src, alt }: { src: string; alt: string }) {
  */
 export default function FaceManagementPage() {
   const {
-    crags, routes, selectedCragId, setSelectedCragId,
+    crags, routes, setRoutes, selectedCragId, setSelectedCragId,
     isLoadingCrags, isLoadingRoutes, stats, updateCragAreas,
   } = useCragRoutes()
 
@@ -416,8 +416,12 @@ export default function FaceManagementPage() {
       if (!res.ok) throw new Error(data.error || '重命名失败')
 
       // 更新本地状态
+      const oldFaceId = selectedFace.faceId
       setR2Faces(prev => prev.map(f =>
-        f.faceId === selectedFace.faceId ? { ...f, faceId: newFaceId } : f
+        f.faceId === oldFaceId ? { ...f, faceId: newFaceId } : f
+      ))
+      setRoutes(prev => prev.map(r =>
+        r.faceId === oldFaceId ? { ...r, faceId: newFaceId } : r
       ))
       setSelectedFace(prev => prev ? {
         ...prev,
@@ -436,7 +440,7 @@ export default function FaceManagementPage() {
     } finally {
       setIsSubmittingRename(false)
     }
-  }, [selectedFace, selectedCragId, renameValue, showToast])
+  }, [selectedFace, selectedCragId, renameValue, showToast, setRoutes])
 
   // ============ 左栏：岩面列表 ============
   const leftPanel = (

--- a/src/app/[locale]/route/route-client.tsx
+++ b/src/app/[locale]/route/route-client.tsx
@@ -3,15 +3,14 @@
 import { useMemo, useCallback, useState, useTransition, useEffect } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useTranslations } from 'next-intl'
-import { ChevronRight, ArrowUp, ArrowDown, X } from 'lucide-react'
+import { ChevronRight } from 'lucide-react'
 import { getGradeColor } from '@/lib/tokens'
 import { FILTER_PARAMS, getGradesByValues, DEFAULT_SORT_DIRECTION, type SortDirection } from '@/lib/filter-constants'
 import { compareGrades } from '@/lib/grade-utils'
 import { getSiblingRoutes } from '@/lib/route-utils'
 import { matchRouteByQuery } from '@/hooks/use-route-search'
-import { FilterChip, FilterChipGroup } from '@/components/filter-chip'
 import { GradeRangeSelectorVertical } from '@/components/grade-range-selector-vertical'
-import { FaceThumbnailStrip } from '@/components/face-thumbnail-strip'
+import { RouteFilterBar } from '@/components/route-filter-bar'
 import { FloatingSearchInput } from '@/components/floating-search-input'
 import { RouteDetailDrawer } from '@/components/route-detail-drawer'
 import { AppTabbar } from '@/components/app-tabbar'
@@ -231,40 +230,25 @@ export default function RouteListClient({ routes, crags }: RouteListClientProps)
           transition: 'var(--theme-transition)',
         }}
       >
-        {/* 顶部 filter 区域 — 全宽 */}
-        <header className="flex-shrink-0 pt-6 px-4 pb-2">
-          <FilterChipGroup>
-            <FilterChip
-              label={tCommon('all')}
-              selected={!selectedCrag}
-              onClick={() => handleCragSelect('')}
-            />
-            {crags.map((crag) => (
-              <FilterChip
-                key={crag.id}
-                label={crag.name}
-                selected={selectedCrag === crag.id}
-                onClick={() => handleCragSelect(crag.id)}
-              />
-            ))}
-          </FilterChipGroup>
-        </header>
-
-        {/* 岩面缩略图 — 全宽 */}
-        {selectedCrag ? (
-          <FaceThumbnailStrip
-            selectedCrag={selectedCrag}
-            selectedFace={selectedFace}
-            onFaceSelect={handleFaceSelect}
-          />
-        ) : (
-          <p
-            className="px-4 pb-2 text-xs"
-            style={{ color: 'var(--theme-on-surface-variant)', opacity: 0.6 }}
-          >
-            {t('faceHint')}
-          </p>
-        )}
+        {/* 顶部筛选栏 — 全宽 */}
+        <RouteFilterBar
+          crags={crags}
+          selectedCrag={selectedCrag}
+          onCragSelect={handleCragSelect}
+          selectedFace={selectedFace}
+          onFaceSelect={handleFaceSelect}
+          sortDirection={sortDirection}
+          onToggleSort={toggleSortDirection}
+          filteredCount={filteredRoutes.length}
+          activeFilterTags={activeFilterTags}
+          allLabel={tCommon('all')}
+          totalCountLabel={t('totalCount', { count: filteredRoutes.length })}
+          sortAscLabel={t('sortAsc')}
+          sortDescLabel={t('sortDesc')}
+          sortAscHint={t('sortAscHint')}
+          sortDescHint={t('sortDescHint')}
+          faceHintLabel={t('faceHint')}
+        />
 
         {/* 中间内容区 — flex row */}
         <div className="flex flex-1 min-h-0">
@@ -282,56 +266,6 @@ export default function RouteListClient({ routes, crags }: RouteListClientProps)
 
           {/* 右侧线路列表 */}
           <main className="flex-1 overflow-y-auto px-4 pb-36">
-            <div className="flex items-center justify-between mb-2">
-              <p className="text-xs" style={{ color: 'var(--theme-on-surface-variant)' }}>
-                {t('totalCount', { count: filteredRoutes.length })}
-              </p>
-              {/* 排序切换按钮 */}
-              <button
-                onClick={toggleSortDirection}
-                className="flex items-center gap-1 px-2 py-1 text-xs font-medium transition-colors"
-                style={{
-                  color: 'var(--theme-on-surface-variant)',
-                  backgroundColor: 'var(--theme-surface-variant)',
-                  borderRadius: 'var(--theme-radius-full)',
-                }}
-                aria-label={sortDirection === 'asc' ? t('sortAscHint') : t('sortDescHint')}
-              >
-                {sortDirection === 'asc' ? (
-                  <>
-                    <ArrowUp className="w-3 h-3" />
-                    <span>{t('sortAsc')}</span>
-                  </>
-                ) : (
-                  <>
-                    <ArrowDown className="w-3 h-3" />
-                    <span>{t('sortDesc')}</span>
-                  </>
-                )}
-              </button>
-            </div>
-
-            {/* ❷ Active filter tags */}
-            {activeFilterTags.length > 0 && (
-              <div className="flex flex-wrap gap-1.5 mb-2">
-                {activeFilterTags.map((tag) => (
-                  <button
-                    key={tag.label}
-                    onClick={tag.onRemove}
-                    className="flex items-center gap-1 px-2 py-0.5 text-xs transition-all active:scale-95"
-                    style={{
-                      color: 'var(--theme-primary)',
-                      backgroundColor: 'color-mix(in srgb, var(--theme-primary) 10%, transparent)',
-                      borderRadius: 'var(--theme-radius-full)',
-                    }}
-                  >
-                    <span className="max-w-24 truncate">{tag.label}</span>
-                    <X className="w-3 h-3 flex-shrink-0 opacity-60" />
-                  </button>
-                ))}
-              </div>
-            )}
-
             <div className="space-y-2">
               {filteredRoutes.map((route, index) => (
                 <button

--- a/src/components/route-filter-bar.tsx
+++ b/src/components/route-filter-bar.tsx
@@ -1,0 +1,141 @@
+'use client'
+
+import { ArrowUp, ArrowDown, X } from 'lucide-react'
+import { FilterChip, FilterChipGroup } from '@/components/filter-chip'
+import { FaceThumbnailStrip } from '@/components/face-thumbnail-strip'
+import type { Crag } from '@/types'
+import type { SortDirection } from '@/lib/filter-constants'
+
+interface FilterTag {
+  label: string
+  onRemove: () => void
+}
+
+interface RouteFilterBarProps {
+  crags: Crag[]
+  selectedCrag: string
+  onCragSelect: (cragId: string) => void
+  selectedFace: string | null
+  onFaceSelect: (faceId: string | null) => void
+  sortDirection: SortDirection
+  onToggleSort: () => void
+  filteredCount: number
+  activeFilterTags: FilterTag[]
+  // i18n
+  allLabel: string
+  totalCountLabel: string
+  sortAscLabel: string
+  sortDescLabel: string
+  sortAscHint: string
+  sortDescHint: string
+  faceHintLabel: string
+}
+
+export function RouteFilterBar({
+  crags,
+  selectedCrag,
+  onCragSelect,
+  selectedFace,
+  onFaceSelect,
+  sortDirection,
+  onToggleSort,
+  filteredCount,
+  activeFilterTags,
+  allLabel,
+  totalCountLabel,
+  sortAscLabel,
+  sortDescLabel,
+  sortAscHint,
+  sortDescHint,
+  faceHintLabel,
+}: RouteFilterBarProps) {
+  return (
+    <div className="flex-shrink-0">
+      {/* 岩场筛选 */}
+      <div className="pt-6 px-4 pb-2">
+        <FilterChipGroup>
+          <FilterChip
+            label={allLabel}
+            selected={!selectedCrag}
+            onClick={() => onCragSelect('')}
+          />
+          {crags.map((crag) => (
+            <FilterChip
+              key={crag.id}
+              label={crag.name}
+              selected={selectedCrag === crag.id}
+              onClick={() => onCragSelect(crag.id)}
+            />
+          ))}
+        </FilterChipGroup>
+      </div>
+
+      {/* 岩面缩略图 */}
+      {selectedCrag ? (
+        <FaceThumbnailStrip
+          selectedCrag={selectedCrag}
+          selectedFace={selectedFace}
+          onFaceSelect={onFaceSelect}
+        />
+      ) : (
+        <p
+          className="px-4 pb-2 text-xs"
+          style={{ color: 'var(--theme-on-surface-variant)', opacity: 0.6 }}
+        >
+          {faceHintLabel}
+        </p>
+      )}
+
+      {/* 数量 + 排序 + 筛选标签 */}
+      <div className="px-4 pb-2">
+        <div className="flex items-center justify-between mb-1">
+          <p className="text-xs" style={{ color: 'var(--theme-on-surface-variant)' }}>
+            {totalCountLabel}
+          </p>
+          <button
+            onClick={onToggleSort}
+            className="flex items-center gap-1 px-2 py-1 text-xs font-medium transition-colors"
+            style={{
+              color: 'var(--theme-on-surface-variant)',
+              backgroundColor: 'var(--theme-surface-variant)',
+              borderRadius: 'var(--theme-radius-full)',
+            }}
+            aria-label={sortDirection === 'asc' ? sortAscHint : sortDescHint}
+          >
+            {sortDirection === 'asc' ? (
+              <>
+                <ArrowUp className="w-3 h-3" />
+                <span>{sortAscLabel}</span>
+              </>
+            ) : (
+              <>
+                <ArrowDown className="w-3 h-3" />
+                <span>{sortDescLabel}</span>
+              </>
+            )}
+          </button>
+        </div>
+
+        {activeFilterTags.length > 0 && (
+          <div className="flex flex-wrap gap-1.5">
+            {activeFilterTags.map((tag) => (
+              <button
+                key={tag.label}
+                onClick={tag.onRemove}
+                className="flex items-center gap-1 px-2 py-0.5 text-xs transition-all active:scale-95"
+                style={{
+                  color: 'var(--theme-primary)',
+                  backgroundColor: 'color-mix(in srgb, var(--theme-primary) 10%, transparent)',
+                  borderRadius: 'var(--theme-radius-full)',
+                }}
+              >
+                <span className="max-w-24 truncate">{tag.label}</span>
+                <X className="w-3 h-3 flex-shrink-0 opacity-60" />
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Extract filter bar UI (crag chips, face thumbnails, sort toggle, active filter tags) from `route-client.tsx` into a reusable `RouteFilterBar` component
- Fix face management: when renaming a faceId, also update `routes` state via `setRoutes` to keep data consistent

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)