### PR TITLE
fix(r2): store raw UTF-8 keys and encode CopySource per segment

### DIFF
--- a/src/app/api/faces/route.ts
+++ b/src/app/api/faces/route.ts
@@ -151,13 +151,15 @@ export async function PATCH(request: NextRequest) {
     }
 
     const client = getS3Client()
-    const oldKey = `${cragId}/${area}/${encodeURIComponent(oldFaceId)}.jpg`
-    const newKey = `${cragId}/${area}/${encodeURIComponent(newFaceId)}.jpg`
+    const oldKey = `${cragId}/${area}/${oldFaceId}.jpg`
+    const newKey = `${cragId}/${area}/${newFaceId}.jpg`
 
     // 1. 复制到新 key
+    // CopySource 需要对 key 中的非 ASCII 字符进行 URI 编码
+    const encodedOldKey = oldKey.split('/').map(s => encodeURIComponent(s)).join('/')
     await client.send(new CopyObjectCommand({
       Bucket: bucketName,
-      CopySource: `${bucketName}/${oldKey}`,
+      CopySource: `${bucketName}/${encodedOldKey}`,
       Key: newKey,
       ContentType: 'image/jpeg',
     }))


### PR DESCRIPTION
## Summary
- Fix R2 key encoding in faces PATCH API: use raw UTF-8 for Key storage instead of percent-encoded strings, preventing CDN 404s on Chinese characters
- Encode CopySource per path segment (S3 HTTP header requirement for non-ASCII)
- Document R2 encoding rules in CLAUDE.md to prevent future regressions

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)