### PR TITLE
fix(editor): clear topo control points when switching face

### DIFF
--- a/src/app/[locale]/editor/routes/page.tsx
+++ b/src/app/[locale]/editor/routes/page.tsx
@@ -738,6 +738,7 @@ export default function RouteAnnotationPage() {
                       // 已选中的岩面不重复操作
                       if (face.faceId === selectedFaceId) return
                       setSelectedFaceId(face.faceId)
+                      setTopoLine([])  // 切换岩面时清空旧控制点
                       const url = getFaceTopoUrl(selectedRoute.cragId, face.area, face.faceId)
                       setImageUrl(url)
                       setIsImageLoading(true)


### PR DESCRIPTION
## Summary
- Clear `topoLine` state when switching between faces in route annotation editor, preventing stale control points from the previous face being rendered on the new face image

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)