### PR TITLE
feat(route): add toggle to show/hide other routes on topo image

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -91,7 +91,9 @@
     "tapToZoom": "Tap to zoom",
     "imageLoadFailed": "Image failed to load",
     "comments": "Comments",
-    "commentsComingSoon": "Comments coming soon..."
+    "commentsComingSoon": "Comments coming soon...",
+    "showOtherRoutes": "Show other routes",
+    "hideOtherRoutes": "Current route only"
   },
   "Weather": {
     "title": "Weather",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -91,7 +91,9 @@
     "tapToZoom": "Appuyez pour zoomer",
     "imageLoadFailed": "Échec du chargement de l'image",
     "comments": "Commentaires",
-    "commentsComingSoon": "Commentaires bientôt disponibles..."
+    "commentsComingSoon": "Commentaires bientôt disponibles...",
+    "showOtherRoutes": "Afficher les autres voies",
+    "hideOtherRoutes": "Voie actuelle uniquement"
   },
   "Weather": {
     "title": "Météo",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -91,7 +91,9 @@
     "tapToZoom": "点击放大",
     "imageLoadFailed": "图片加载失败",
     "comments": "评论",
-    "commentsComingSoon": "评论功能开发中..."
+    "commentsComingSoon": "评论功能开发中...",
+    "showOtherRoutes": "显示其他线路",
+    "hideOtherRoutes": "仅看当前线路"
   },
   "Weather": {
     "title": "天气",


### PR DESCRIPTION
## Summary
- Add Eye/EyeOff toggle button on topo image to show/hide sibling routes on the same face
- Available in both drawer preview and fullscreen image viewer
- Shows count of other routes as badge
- i18n strings for zh/en/fr

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)