### PR TITLE
refactor(topo): remove endpoint circle markers from topo overlays

### DIFF
--- a/src/components/multi-topo-line-overlay.tsx
+++ b/src/components/multi-topo-line-overlay.tsx
@@ -80,7 +80,7 @@ export const MultiTopoLineOverlay = forwardRef<MultiTopoLineOverlayRef, MultiTop
 
     // 预计算所有线路的路径数据
     const routePathData = useMemo(() => {
-      const map = new Map<number, { path: string; start: TopoPoint; end: TopoPoint }>()
+      const map = new Map<number, { path: string; start: TopoPoint }>()
 
       routes.forEach(route => {
         if (route.topoLine.length < 2) return
@@ -89,7 +89,6 @@ export const MultiTopoLineOverlay = forwardRef<MultiTopoLineOverlayRef, MultiTop
         map.set(route.id, {
           path: bezierCurve(scaledPoints),
           start: scaledPoints[0],
-          end: scaledPoints[scaledPoints.length - 1],
         })
       })
 
@@ -274,15 +273,7 @@ export const MultiTopoLineOverlay = forwardRef<MultiTopoLineOverlayRef, MultiTop
               }}
             />
 
-            {/* 终点 */}
-            <circle
-              cx={selectedData.end.x}
-              cy={selectedData.end.y}
-              r={TOPO_MARKER_CONFIG.endRadius}
-              fill="white"
-              stroke={selectedColor}
-              strokeWidth={TOPO_MARKER_CONFIG.endStrokeWidth}
-            />
+
           </g>
         )}
       </svg>

--- a/src/components/topo-line-overlay.tsx
+++ b/src/components/topo-line-overlay.tsx
@@ -81,9 +81,8 @@ export const TopoLineOverlay = forwardRef<TopoLineOverlayRef, TopoLineOverlayPro
     // 生成贝塞尔曲线路径
     const pathData = useMemo(() => bezierCurve(scaledPoints), [scaledPoints])
 
-    // 起点和终点
+    // 起点
     const startPoint = scaledPoints[0]
-    const endPoint = scaledPoints[scaledPoints.length - 1]
 
     // 画线动画函数
     const animate = useCallback(() => {
@@ -181,15 +180,7 @@ export const TopoLineOverlay = forwardRef<TopoLineOverlayRef, TopoLineOverlayPro
           }}
         />
 
-        {/* 终点 */}
-        <circle
-          cx={endPoint.x}
-          cy={endPoint.y}
-          r={TOPO_MARKER_CONFIG.endRadius}
-          fill="white"
-          stroke={color}
-          strokeWidth={TOPO_MARKER_CONFIG.endStrokeWidth}
-        />
+
       </svg>
     )
   }


### PR DESCRIPTION
## Summary
- Remove endpoint (finish) circle markers from both `TopoLineOverlay` and `MultiTopoLineOverlay`
- Remove unused `end` field from route path data in multi-line overlay
- Only start point markers are retained

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)