### PR TITLE
refactor(crag-card): simplify layout to gradient-only design

### DIFF
--- a/src/app/[locale]/editor/routes/page.tsx
+++ b/src/app/[locale]/editor/routes/page.tsx
@@ -877,21 +877,21 @@ export default function RouteAnnotationPage() {
                       <g key={index}>
                         <circle
                           cx={point.x} cy={point.y}
-                          r={index === 0 ? 10 : index === scaledPoints.length - 1 ? 8 : 6}
+                          r={index === 0 ? 6 : index === scaledPoints.length - 1 ? 5 : 4}
                           fill={index === 0 ? routeColor : 'white'}
                           stroke={index === 0 ? 'white' : routeColor}
-                          strokeWidth={index === 0 ? 2 : 3}
+                          strokeWidth={index === 0 ? 1.5 : 2}
                         />
-                        <text x={point.x} y={point.y + 4} textAnchor="middle" fontSize="10" fontWeight="bold" fill={index === 0 ? 'white' : routeColor}>
+                        <text x={point.x} y={point.y + 2.5} textAnchor="middle" fontSize="7" fontWeight="bold" fill={index === 0 ? 'white' : routeColor}>
                           {index + 1}
                         </text>
                       </g>
                     ))}
                     {scaledPoints.length > 0 && (
-                      <text x={scaledPoints[0].x - 15} y={scaledPoints[0].y + 25} fill={routeColor} fontSize="12" fontWeight="bold">起点</text>
+                      <text x={scaledPoints[0].x - 12} y={scaledPoints[0].y + 18} fill={routeColor} fontSize="10" fontWeight="bold">起点</text>
                     )}
                     {scaledPoints.length > 1 && (
-                      <text x={scaledPoints[scaledPoints.length - 1].x - 15} y={scaledPoints[scaledPoints.length - 1].y - 15} fill={routeColor} fontSize="12" fontWeight="bold">终点</text>
+                      <text x={scaledPoints[scaledPoints.length - 1].x - 12} y={scaledPoints[scaledPoints.length - 1].y - 12} fill={routeColor} fontSize="10" fontWeight="bold">终点</text>
                     )}
                   </svg>
                 </div>

--- a/src/components/crag-card.test.tsx
+++ b/src/components/crag-card.test.tsx
@@ -7,10 +7,22 @@ import { render, screen } from '@testing-library/react'
 import { CragCard } from './crag-card'
 import type { Crag, Route } from '@/types'
 
-// Mock next/link
+// Mock next/link - 传递所有常用属性
 vi.mock('next/link', () => ({
-  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
-    <a href={href}>{children}</a>
+  default: ({
+    children,
+    href,
+    className,
+    style,
+  }: {
+    children: React.ReactNode
+    href: string
+    className?: string
+    style?: React.CSSProperties
+  }) => (
+    <a href={href} className={className} style={style}>
+      {children}
+    </a>
   ),
 }))
 
@@ -104,20 +116,18 @@ describe('CragCard', () => {
     })
   })
 
-  describe('封面图片', () => {
-    it('有封面图时渲染 Image 组件', () => {
-      render(<CragCard crag={mockCragWithImage} routes={mockRoutes} />)
-      const img = screen.getByRole('img')
-      expect(img).toHaveAttribute('alt', '测试岩场')
+  describe('渐变背景', () => {
+    it('卡片使用渐变背景', () => {
+      render(<CragCard crag={mockCrag} routes={mockRoutes} />)
+      // 渐变背景应用在 Link 元素上
+      const link = screen.getByRole('link')
+      expect(link.getAttribute('style')).toContain('linear-gradient')
     })
 
-    it('无封面图时显示渐变背景', () => {
-      const { container } = render(<CragCard crag={mockCrag} routes={mockRoutes} />)
-      // 无图片时应该没有 img 元素
+    it('不再渲染图片元素（统一使用渐变）', () => {
+      render(<CragCard crag={mockCragWithImage} routes={mockRoutes} />)
+      // 即使有 coverImages，也不应该渲染 img 元素
       expect(screen.queryByRole('img')).not.toBeInTheDocument()
-      // 应该有渐变背景的容器
-      const gradientDiv = container.querySelector('[style*="linear-gradient"]')
-      expect(gradientDiv).toBeInTheDocument()
     })
   })
 

--- a/src/components/crag-card.tsx
+++ b/src/components/crag-card.tsx
@@ -1,11 +1,9 @@
 'use client'
 
 import Link from 'next/link'
-import Image from 'next/image'
-import { MapPin, Route as RouteIcon } from 'lucide-react'
+import { MapPin, GitBranch } from 'lucide-react'
 import type { Crag, Route, WeatherData } from '@/types'
 import { getCragTheme } from '@/lib/crag-theme'
-import { getGradeColor } from '@/lib/tokens'
 import { compareGrades } from '@/lib/grade-utils'
 import { WeatherBadge } from '@/components/weather-badge'
 import { DownloadButton } from '@/components/download-button'
@@ -36,128 +34,97 @@ export function CragCard({ crag, routes = [], index = 0, weather, showDownload =
   const maxGrade = grades[grades.length - 1] || minGrade
   const gradeRange = minGrade === maxGrade ? minGrade : `${minGrade}-${maxGrade}`
 
-  const hasCoverImage = crag.coverImages && crag.coverImages.length > 0
-
   return (
     <Link
       href={`/crag/${crag.id}`}
-      className="group relative block overflow-hidden rounded-2xl
+      className="group relative block overflow-hidden rounded-2xl p-4
                  shadow-sm hover:shadow-xl transition-all duration-300
                  active:scale-[0.97] active:shadow-md
                  animate-fade-in-up touch-manipulation"
-      style={{ animationDelay: `${index * 80}ms` }}
+      style={{
+        animationDelay: `${index * 80}ms`,
+        background: theme.gradient,
+      }}
     >
-      {/* 背景层 - 图片或渐变 */}
-      <div className="relative h-44 overflow-hidden">
-        {/* 顶部工具栏 (右上角) - 天气 + 下载按钮 */}
-        <div className="absolute top-3 right-3 z-10 flex items-center gap-2">
-          {/* 下载按钮 */}
-          {showDownload && offlineDownload && offlineDownload.isSupported && (
-            <DownloadButton
-              crag={crag}
-              routes={routes}
-              isDownloaded={offlineDownload.isDownloaded(crag.id)}
-              progress={offlineDownload.downloadProgress}
-              onDownload={offlineDownload.downloadCrag}
-              onDelete={offlineDownload.deleteCrag}
-            />
-          )}
-
-          {/* 天气角标 */}
-          {weather && (
-            <WeatherBadge
-              temperature={weather.live.temperature}
-              weather={weather.live.weather}
-            />
-          )}
-        </div>
-
-        {hasCoverImage ? (
-          // 有封面图时显示图片
-          <Image
-            src={crag.coverImages![0]}
-            alt={crag.name}
-            fill
-            priority={index < 2}
-            sizes="100vw"
-            className="object-cover transition-transform duration-500
-                       group-hover:scale-105"
-          />
-        ) : (
-          // 无图片时显示渐变背景 + 装饰元素
-          <div
-            className="absolute inset-0 transition-transform duration-500
-                       group-hover:scale-105"
-            style={{ background: theme.gradient }}
-          >
-            {/* 装饰性图标 */}
-            <span
-              className="absolute right-4 top-4 text-5xl opacity-30
-                         transition-all duration-300 group-hover:opacity-50
-                         group-hover:scale-110"
-            >
-              {theme.icon}
-            </span>
-
-            {/* 纹理叠加层 */}
-            <div
-              className="absolute inset-0 opacity-20"
-              style={{
-                backgroundImage: `url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%' height='100%' filter='url(%23noise)'/%3E%3C/svg%3E")`,
-              }}
-            />
-          </div>
-        )}
-
-        {/* 底部渐变遮罩 */}
-        <div
-          className="absolute inset-0 bg-gradient-to-t
-                     from-black/70 via-black/20 to-transparent"
-        />
-
-        {/* 内容层 */}
-        <div className="absolute inset-0 flex flex-col justify-end p-4">
+      {/* 垂直布局容器 */}
+      <div className="flex flex-col gap-3">
+        {/* 顶部行: 标题 + 操作按钮 */}
+        <div className="flex items-start justify-between gap-2">
           {/* 岩场名称 */}
-          <h3
-            className="text-2xl font-bold text-white tracking-wide
-                       drop-shadow-lg"
-          >
+          <h3 className="text-[22px] font-bold text-white leading-tight">
             {crag.name}
           </h3>
 
-          {/* 信息行 */}
-          <div className="flex items-center gap-3 mt-2">
-            {/* 线路数量 */}
-            <div
-              className="flex items-center gap-1.5 px-2.5 py-1
-                         bg-white/20 backdrop-blur-sm rounded-full"
-            >
-              <RouteIcon className="w-3.5 h-3.5 text-white" />
-              <span className="text-sm text-white font-medium">
-                {routeCount} 条线路
-              </span>
-            </div>
+          {/* 操作按钮组 */}
+          <div className="flex items-center gap-2 flex-shrink-0">
+            {/* 下载按钮 */}
+            {showDownload && offlineDownload && offlineDownload.isSupported && (
+              <DownloadButton
+                crag={crag}
+                routes={routes}
+                isDownloaded={offlineDownload.isDownloaded(crag.id)}
+                progress={offlineDownload.downloadProgress}
+                onDownload={offlineDownload.downloadCrag}
+                onDelete={offlineDownload.deleteCrag}
+                className="!w-8 !h-8 !rounded-lg"
+                style={{
+                  backgroundColor: 'rgba(0, 0, 0, 0.2)',
+                  boxShadow: 'none',
+                }}
+              />
+            )}
 
-            {/* 难度范围 */}
-            <div
-              className="px-2.5 py-1 rounded-full text-sm font-bold text-white"
-              style={{
-                backgroundColor: getGradeColor(minGrade),
-                boxShadow: `0 2px 8px ${getGradeColor(minGrade)}40`,
-              }}
-            >
-              {gradeRange}
-            </div>
+            {/* 天气徽章 */}
+            {weather && (
+              <WeatherBadge
+                temperature={weather.live.temperature}
+                weather={weather.live.weather}
+                className="!h-7 !rounded-lg"
+                style={{
+                  backgroundColor: 'rgba(12, 12, 12, 0.8)',
+                }}
+              />
+            )}
+          </div>
+        </div>
+
+        {/* 标签行: 线路数 + 难度范围 */}
+        <div className="flex items-center gap-2">
+          {/* 线路数量标签 */}
+          <div
+            className="flex items-center gap-1.5 h-[26px] px-2.5 rounded-md"
+            style={{ backgroundColor: 'rgba(255, 255, 255, 0.1)' }}
+          >
+            <GitBranch className="w-3.5 h-3.5 text-white" />
+            <span className="text-xs text-white font-medium">
+              {routeCount} 条线路
+            </span>
           </div>
 
-          {/* 位置信息 (可选) */}
-          {crag.location && (
-            <div className="flex items-center gap-1 mt-2 text-white/70">
-              <MapPin className="w-3 h-3" />
-              <span className="text-xs truncate">{crag.location}</span>
-            </div>
-          )}
+          {/* 难度范围标签 */}
+          <div
+            className="h-[26px] px-2.5 rounded-md flex items-center"
+            style={{
+              backgroundColor: '#FFFFFF',
+              color: '#0C0C0C',
+            }}
+          >
+            <span className="text-xs font-bold">{gradeRange}</span>
+          </div>
         </div>
+
+        {/* 位置信息行 */}
+        {crag.location && (
+          <div className="flex items-center gap-1">
+            <MapPin className="w-3 h-3" style={{ color: 'rgba(255, 255, 255, 0.67)' }} />
+            <span
+              className="text-[11px] truncate"
+              style={{ color: 'rgba(255, 255, 255, 0.67)' }}
+            >
+              {crag.location}
+            </span>
+          </div>
+        )}
       </div>
     </Link>
   )

--- a/src/components/download-button.tsx
+++ b/src/components/download-button.tsx
@@ -26,6 +26,7 @@ interface DownloadButtonProps {
   onDelete?: (cragId: string) => Promise<void>
   variant?: 'icon' | 'badge'  // icon=仅图标按钮, badge=已下载徽章
   className?: string
+  style?: React.CSSProperties
 }
 
 /**
@@ -86,6 +87,7 @@ export function DownloadButton({
   onDelete,
   variant = 'icon',
   className,
+  style,
 }: DownloadButtonProps) {
   const t = useTranslations('Offline')
   const { showToast } = useToast()
@@ -184,6 +186,7 @@ export function DownloadButton({
       )}
       style={{
         boxShadow: '0 2px 8px rgba(0,0,0,0.2)',
+        ...style,
       }}
       title={
         status === 'idle' ? t('download') :

--- a/src/components/editor/fullscreen-topo-editor.tsx
+++ b/src/components/editor/fullscreen-topo-editor.tsx
@@ -183,16 +183,16 @@ export function FullscreenTopoEditor({
                     <circle
                       cx={point.x}
                       cy={point.y}
-                      r={index === 0 ? 10 : index === fsScaledPoints.length - 1 ? 8 : 6}
+                      r={index === 0 ? 6 : index === fsScaledPoints.length - 1 ? 5 : 4}
                       fill={index === 0 ? routeColor : 'white'}
                       stroke={index === 0 ? 'white' : routeColor}
-                      strokeWidth={index === 0 ? 2 : 3}
+                      strokeWidth={index === 0 ? 1.5 : 2}
                     />
                     <text
                       x={point.x}
-                      y={point.y + 4}
+                      y={point.y + 2.5}
                       textAnchor="middle"
-                      fontSize="10"
+                      fontSize="7"
                       fontWeight="bold"
                       fill={index === 0 ? 'white' : routeColor}
                     >
@@ -202,10 +202,10 @@ export function FullscreenTopoEditor({
                 ))}
                 {fsScaledPoints.length > 0 && (
                   <text
-                    x={fsScaledPoints[0].x - 15}
-                    y={fsScaledPoints[0].y + 25}
+                    x={fsScaledPoints[0].x - 12}
+                    y={fsScaledPoints[0].y + 18}
                     fill={routeColor}
-                    fontSize="12"
+                    fontSize="10"
                     fontWeight="bold"
                   >
                     起点
@@ -213,10 +213,10 @@ export function FullscreenTopoEditor({
                 )}
                 {fsScaledPoints.length > 1 && (
                   <text
-                    x={fsScaledPoints[fsScaledPoints.length - 1].x - 15}
-                    y={fsScaledPoints[fsScaledPoints.length - 1].y - 15}
+                    x={fsScaledPoints[fsScaledPoints.length - 1].x - 12}
+                    y={fsScaledPoints[fsScaledPoints.length - 1].y - 12}
                     fill={routeColor}
-                    fontSize="12"
+                    fontSize="10"
                     fontWeight="bold"
                   >
                     终点

--- a/src/components/weather-badge.tsx
+++ b/src/components/weather-badge.tsx
@@ -1,23 +1,30 @@
 'use client'
 
 import { getWeatherIcon } from '@/lib/weather-constants'
+import { cn } from '@/lib/utils'
 
 interface WeatherBadgeProps {
   temperature: number
   weather: string
+  className?: string
+  style?: React.CSSProperties
 }
 
 /**
  * 卡片天气角标
  * 显示温度和天气图标，位置由父容器控制
  */
-export function WeatherBadge({ temperature, weather }: WeatherBadgeProps) {
+export function WeatherBadge({ temperature, weather, className, style }: WeatherBadgeProps) {
   const icon = getWeatherIcon(weather)
 
   return (
     <div
-      className="flex items-center gap-1 px-2 py-1
-                 bg-black/50 backdrop-blur-sm rounded-full"
+      className={cn(
+        'flex items-center gap-1 px-2 py-1',
+        'bg-black/50 backdrop-blur-sm rounded-full',
+        className
+      )}
+      style={style}
     >
       <span className="text-white text-sm font-medium">{temperature}°</span>
       <span className="text-sm">{icon}</span>


### PR DESCRIPTION
## Summary
- Remove cover image dependency, use theme gradient as background
- Restructure CragCard to vertical layout with better spacing
- Add className/style props to WeatherBadge and DownloadButton for flexibility
- Update tests for new component structure

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)