### PR TITLE
fix(api): correct getDatabase import source in upload route

### DIFF
--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { S3Client, PutObjectCommand, HeadObjectCommand } from '@aws-sdk/client-s3'
 import { createModuleLogger } from '@/lib/logger'
 import { sanitizePathSegment } from '@/lib/request-utils'
-import { getDatabase } from '@/lib/db'
+import { getDatabase } from '@/lib/mongodb'
 
 const log = createModuleLogger('API:Upload')
 


### PR DESCRIPTION
## Summary
- Fix Vercel deployment build failure caused by incorrect import in `src/app/api/upload/route.ts`
- `getDatabase` was imported from `@/lib/db` (data access layer, doesn't export it) instead of `@/lib/mongodb` (connection layer)
- This was introduced in PR #186 when adding the topoLine cascade clear feature

## Test plan
- [x] `npm run build` passes locally after the fix
- [ ] Vercel preview deployment succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)