### PR TITLE
ux(editor): 优化岩面管理页面交互体验

### DIFF
--- a/src/app/[locale]/editor/faces/page.tsx
+++ b/src/app/[locale]/editor/faces/page.tsx
@@ -1005,6 +1005,7 @@ export default function FaceManagementPage() {
                         <button
                           key={face.faceId}
                           onClick={() => { setSelectedFace(face); setIsRenaming(false) }}
+                          aria-selected={isActive}
                           className="flex-shrink-0 flex flex-col items-center gap-1 transition-all active:scale-95"
                         >
                           <div


### PR DESCRIPTION
## Summary

- 将「新建岩面」按钮从列表底部移到顶部（区域筛选下方），提高可发现性
- Header 返回按钮动态化：移动端详情模式→返回列表，列表模式→返回编辑器；触控区域加大至 44pt
- 移动端详情页顶部添加缩略图横向滚动条，无需返回列表即可快速切换岩面

## Test Plan

- [x] ESLint: 0 errors
- [x] TypeScript: 0 errors
- [x] Vitest: 693 tests passing
- [x] Playwright: 12 tests passing
- [ ] 手动验证：桌面端新建按钮位置、Header 返回行为
- [ ] 手动验证：移动端 Header 动态返回、缩略图条切换

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)