### PR TITLE
fix: persist topoAnnotations from editor and revalidate route page

### DIFF
--- a/apps/editor/src/app/api/routes/[id]/route.ts
+++ b/apps/editor/src/app/api/routes/[id]/route.ts
@@ -201,6 +201,37 @@ export async function PATCH(
       }
     }
 
+    // 验证 topoAnnotations
+    if (body.topoAnnotations !== undefined) {
+      if (body.topoAnnotations === null || (Array.isArray(body.topoAnnotations) && body.topoAnnotations.length === 0)) {
+        updates.topoAnnotations = []
+      } else if (!Array.isArray(body.topoAnnotations)) {
+        return NextResponse.json(
+          { success: false, error: 'topoAnnotations 必须是数组' },
+          { status: 400 }
+        )
+      } else {
+        for (const annotation of body.topoAnnotations) {
+          if (
+            typeof annotation.faceId !== 'string' ||
+            typeof annotation.area !== 'string' ||
+            !validateTopoLine(annotation.topoLine)
+          ) {
+            return NextResponse.json(
+              { success: false, error: 'topoAnnotations 中的标注数据格式无效' },
+              { status: 400 }
+            )
+          }
+        }
+        updates.topoAnnotations = body.topoAnnotations.map((a: Record<string, unknown>) => ({
+          faceId: a.faceId,
+          area: a.area,
+          topoLine: a.topoLine,
+          ...(typeof a.topoTension === 'number' ? { topoTension: a.topoTension } : {}),
+        }))
+      }
+    }
+
     // 检查是否有需要更新的字段
     if (Object.keys(updates).length === 0) {
       return NextResponse.json(

--- a/apps/editor/src/lib/revalidate-pwa.ts
+++ b/apps/editor/src/lib/revalidate-pwa.ts
@@ -45,10 +45,10 @@ export async function revalidatePwa(options: {
   }
 }
 
-/** 重验证岩场相关页面 */
+/** 重验证岩场相关页面 + 线路列表页 */
 export async function revalidateCragPages(cragId: string) {
   await revalidatePwa({
-    paths: [`/crag/${cragId}`, '/'],
+    paths: [`/crag/${cragId}`, '/', '/route'],
   })
 }
 


### PR DESCRIPTION
## Summary
- Add `topoAnnotations` validation and persistence to Editor's PATCH handler (was silently dropped)
- Add `/route` to ISR revalidation paths so route list page refreshes after save

## Test plan
- [x] TypeScript typecheck passes (all 4 packages)
- [x] Vitest: 659 PWA tests + 88 Editor tests pass
- [x] Playwright: 12 component tests pass
- [ ] Manual: Editor → save route with multi-face annotations → verify PWA RouteDetailDrawer shows carousel

🤖 Generated with [Claude Code](https://claude.com/claude-code)